### PR TITLE
Added serialization for udtf and lvj OI's in LateralViewJoinOperator + lateral view tests. fix for #25. 

### DIFF
--- a/src/main/scala/shark/exec/LateralViewJoinOperator.scala
+++ b/src/main/scala/shark/exec/LateralViewJoinOperator.scala
@@ -2,6 +2,7 @@ package shark.exec
 
 import java.util.ArrayList
 
+import org.apache.commons.codec.binary.Base64
 import org.apache.hadoop.hive.ql.exec.{ExprNodeEvaluator, ExprNodeEvaluatorFactory, LateralViewJoinOperator => HiveLateralViewJoinOperator}
 import org.apache.hadoop.hive.ql.plan.SelectDesc
 import org.apache.hadoop.hive.serde2.objectinspector.{ ObjectInspector, StructObjectInspector }
@@ -110,11 +111,11 @@ object KryoSerializerToString extends shark.LogHelper {
 
   def serialize[T](o: T): String = {
     val bytes = kryoSer.newInstance().serialize(o)
-    new String(bytes, "ISO-8859-1")
+    new String(Base64.encodeBase64(bytes))
     }
 
   def deserialize[T](byteString: String): T  = {
-    val bytes = byteString.getBytes("ISO-8859-1")
+    val bytes = Base64.decodeBase64(byteString.getBytes())
     kryoSer.newInstance().deserialize[T](bytes)
   }
 }

--- a/src/main/scala/shark/exec/LateralViewJoinOperator.scala
+++ b/src/main/scala/shark/exec/LateralViewJoinOperator.scala
@@ -58,7 +58,6 @@ class LateralViewJoinOperator extends NaryOperator[HiveLateralViewJoinOperator] 
   override def execute: RDD[_] = {
     // Execute LateralViewForwardOperator, bypassing Select / UDTF - Select
     // branches (see diagram in Hive's).
-
     val inputRDD = lvfOp.execute()
 
     Operator.executeProcessPartition(this, inputRDD)

--- a/src/main/scala/shark/exec/LateralViewJoinOperator.scala
+++ b/src/main/scala/shark/exec/LateralViewJoinOperator.scala
@@ -110,11 +110,11 @@ object KryoSerializerToString extends shark.LogHelper {
 
   def serialize[T](o: T): String = {
     val bytes = kryoSer.newInstance().serialize(o)
-    new String(bytes.map(_.toChar))
+    new String(bytes, "ISO-8859-1")
     }
 
   def deserialize[T](byteString: String): T  = {
-    val bytes = byteString.toCharArray.map(_.toByte)
+    val bytes = byteString.getBytes("ISO-8859-1")
     kryoSer.newInstance().deserialize[T](bytes)
   }
 }

--- a/src/test/tests_pass.txt
+++ b/src/test/tests_pass.txt
@@ -200,6 +200,8 @@ testCliDriver_join8
 testCliDriver_join9
 testCliDriver_join_hive_626
 testCliDriver_join_rc
+testCliDriver_lateral_view
+testCliDriver_lateral_view_ppd
 testCliDriver_lineage1
 testCliDriver_load_dyn_part1
 testCliDriver_load_dyn_part10
@@ -494,6 +496,8 @@ testCliDriver_udf_xpath_int
 testCliDriver_udf_xpath_long
 testCliDriver_udf_xpath_short
 testCliDriver_udf_xpath_string
+testCliDriver_udtf_parse_url_tuple
+testCliDriver_udtf_json_tuple
 testCliDriver_union
 testCliDriver_union10
 testCliDriver_union11


### PR DESCRIPTION
In LateralViewJoinOperator.scala, used Kryo to serialize udtf and lvf OI's and converted the byte arrays to strings so the @BeanProperty keyword/XML serialization is less inefficient. 
Also removed some unused imports.

Passed these tests on cluster and local computer that use lateral view:
testCliDriver_lateral_view
testCliDriver_lateral_view_ppd
testCliDriver_load_dyn_part15 (originally failed in issue #25)
testCliDriver_udtf_json_tuple
testCliDriver_udtf_parse_url_tuple

Added to tests_pass.txt:
testCliDriver_lateral_view
testCliDriver_lateral_view_ppd 
testCliDriver_udtf_json_tuple
testCliDriver_udtf_parse_url_tuple
