### PR TITLE
Thrift interface/ Hive Server integration for Shark

### DIFF
--- a/bin/ext/cli.sh
+++ b/bin/ext/cli.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+bin="`dirname $0`"
+FWDIR="`dirname $bin`"
+
+THISSERVICE=cli
+export SERVICE_LIST="${SERVICE_LIST}${THISSERVICE} "
+
+cli() {
+  echo "Starting the Shark Command Line Client"
+  $FWDIR/run shark.SharkCliDriver "$@"
+}
+
+cli_help() {
+ echo "usage  ./shark --service cli"
+}

--- a/bin/ext/sharkserver.sh
+++ b/bin/ext/sharkserver.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+bin="`dirname $0`"
+FWDIR="`dirname $bin`"
+
+THISSERVICE=sharkserver
+export SERVICE_LIST="${SERVICE_LIST}${THISSERVICE} "
+
+sharkserver() {
+  echo "Starting the Shark Server" 
+  $FWDIR/run shark.SharkServer  "$@"
+}
+
+sharkserver_help() {
+ echo "usage SHARK_PORT=xxxx ./shark --service sharkserver"
+ echo "SHARK_PORT : Specify the server port"
+}

--- a/bin/shark
+++ b/bin/shark
@@ -1,4 +1,53 @@
 #!/bin/sh
-BINDIR="`dirname $0`"
-FWDIR="`dirname $BINDIR`"
-exec $FWDIR/run shark.SharkCliDriver "$@"
+bin="`dirname $0`"
+FWDIR="`dirname $bin`"
+bin=`cd "$bin"; pwd`
+
+
+SERVICE=""
+HELP=""
+while [ $# -gt 0 ];do
+  case "$1" in
+   --service)
+     shift
+     SERVICE=$1
+     shift
+     ;;
+   --help)
+     HELP=_help
+     shift
+     ;;
+     *)
+     break
+     ;;
+  esac
+done
+
+if [ "$SERVICE" = "" ] ; then
+  if [ "$HELP" = "_help" ] ; then
+    SERVICE="help"
+  else
+    SERVICE="cli"
+  fi
+fi
+SERVICE_LIST=""
+
+for i in "$bin"/ext/*.sh ; do
+  . $i
+done
+
+TORUN=""
+for j in $SERVICE_LIST ; do
+  if [ "$j" = "$SERVICE" ] ; then
+    TORUN=${j}$HELP
+  fi
+done
+echo "$@"
+if [ "$TORUN" = "" ] ; then
+  echo "Service $SERVICE not found"
+  echo "Available Services: $SERVICE_LIST"
+  exit 7
+else
+  $TORUN "$@"
+fi
+

--- a/src/main/scala/shark/SharkServer.scala
+++ b/src/main/scala/shark/SharkServer.scala
@@ -83,7 +83,7 @@ class SharkServerHandler extends HiveServerHandler {
     val cmd_trimmed = cmd.trim()
     val tokens = cmd_trimmed.split("\\s")
     val cmd_1 = cmd_trimmed.substring(tokens.apply(0).length()).trim()
-    println("Executing command:  "+ cmd)
+    
 
 
     val proc = CommandProcessorFactory.get(tokens.apply(0))

--- a/src/main/scala/shark/SharkServer.scala
+++ b/src/main/scala/shark/SharkServer.scala
@@ -73,7 +73,7 @@ class SharkServerHandler extends HiveServerHandler {
     val cmd_trimmed = cmd.trim()
     val tokens = cmd_trimmed.split("\\s")
     val cmd_1 = cmd_trimmed.substring(tokens.apply(0).length()).trim()
-    
+
     var response: Option[CommandProcessorResponse]  = None
 
     val proc = CommandProcessorFactory.get(tokens.apply(0))
@@ -89,10 +89,12 @@ class SharkServerHandler extends HiveServerHandler {
 
     }
 
-    throw response match {
-      case None => new HiveServerException
-      case Some(error) => val responseCode = error.getResponseCode ; new HiveServerException("Query returned non-zero code: " + responseCode
-        + ", cause: " + error.getErrorMessage, responseCode, error.getSQLState)
+    response match {
+      case None => throw new HiveServerException
+      case Some(resp) => {
+        val responseCode = resp.getResponseCode
+        if (responseCode != 0) throw new HiveServerException("Query returned non-zero code: " + responseCode
+        + ", cause: " + resp.getErrorMessage, responseCode, resp.getSQLState)   }
     }
   }
 

--- a/src/main/scala/shark/SharkServer.scala
+++ b/src/main/scala/shark/SharkServer.scala
@@ -1,0 +1,156 @@
+package shark
+
+import shark.{SharkEnv, SharkDriver}
+
+import org.apache.hadoop.hive.service.ThriftHive
+import org.apache.hadoop.hive.service.HiveServer.{ThriftHiveProcessorFactory, HiveServerHandler}
+import org.apache.thrift.transport.{TTransport, TTransportFactory, TServerSocket}
+import org.apache.thrift.server.TThreadPoolServer
+import org.apache.thrift.protocol.TBinaryProtocol
+import org.apache.hadoop.hive.ql.session.SessionState
+import org.apache.thrift.TProcessor
+import org.apache.commons.logging.LogFactory
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.ql.Driver
+import org.apache.hadoop.hive.ql.processors.CommandProcessorFactory
+import org.apache.hadoop.hive.conf.HiveConf
+import spark.SparkContext
+import java.util.ArrayList
+import org.apache.hadoop.hive.metastore.api.Schema
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: harsha
+ * Date: 7/5/12
+ * Time: 10:23 PM
+ * To change this template use File | Settings | File Templates.
+ */
+
+
+
+object SharkServer {
+
+  private val LOG = LogFactory.getLog("SharkServer")
+  SharkEnv.sc = new SparkContext(
+    if (System.getenv("MASTER") == null) "local" else System.getenv("MASTER"),
+    "Shark::" + java.net.InetAddress.getLocalHost.getHostName)
+
+  def main(args:Array[String]){
+    SessionState.initHiveLog4j();
+
+    var port = 10000;
+    var minWorkerThreads = 100// default number of threads serving the Hive server
+    if (args.length >= 1) port = Integer.parseInt(args.apply(0))
+    if (args.length >= 2) minWorkerThreads = Integer.parseInt(args.apply(1))
+
+    val serverTransport = new TServerSocket(port);
+    val hfactory = new SharkHiveProcessingFactory(null)
+    val options = new TThreadPoolServer.Options()
+    options.minWorkerThreads = minWorkerThreads
+    val server = new TThreadPoolServer(hfactory, serverTransport,
+      new TTransportFactory(), new TTransportFactory(),
+      new TBinaryProtocol.Factory(), new TBinaryProtocol.Factory(), options)
+    LOG.info("Starting shark server on port " + port)
+    server.serve()
+  }
+}
+
+class SharkHiveProcessingFactory(processor:TProcessor) extends ThriftHiveProcessorFactory(processor){
+
+  override def getProcessor(trans: TTransport) = new ThriftHive.Processor(new SharkServerHandler)
+}
+
+class SharkServerHandler extends HiveServerHandler {
+
+  private val ss = SessionState.get()
+
+  private val conf: Configuration = if (ss != null) ss.getConf() else new Configuration()
+
+  private val driver = {
+    val d =new SharkDriver(conf.asInstanceOf[HiveConf])
+    d.init()
+    d
+  }
+
+  private var isSharkQuery = false
+
+  private val LOG = LogFactory.getLog("SharkServerHandler")
+
+
+  override def execute(cmd: String) {
+    SessionState.get();
+
+    val cmd_trimmed = cmd.trim()
+    val tokens = cmd_trimmed.split("\\s")
+    val cmd_1 = cmd_trimmed.substring(tokens.apply(0).length()).trim()
+    println("Executing command:  "+ cmd)
+
+
+    val proc = CommandProcessorFactory.get(tokens.apply(0))
+    if (proc != null) {
+      if (proc.isInstanceOf[Driver]) {
+        isSharkQuery = true
+        proc.asInstanceOf[Driver].destroy()
+        driver.run(cmd)
+      } else {
+        isSharkQuery = false
+        proc.run(cmd_1)
+      }
+
+    }
+  }
+
+  override def fetchAll() = {
+    val res = new ArrayList[String]()
+    if (isSharkQuery) {
+      driver.getResults(res)
+    }
+    res
+  }
+
+  override def fetchN(numRows: Int) = {
+    val res = new ArrayList[String]()
+    if (isSharkQuery) {
+      driver.setMaxRows(numRows)
+      driver.getResults(res)
+    }
+    res
+  }
+
+  override def fetchOne() = {
+    if(!isSharkQuery) {
+      ""
+    }else {
+      val list = fetchN(1)
+      if (list.isEmpty)
+        ""
+      else list.get(0)
+    }
+  }
+
+  override def getSchema = {
+    if(!isSharkQuery) {
+      new Schema
+    }else {
+      val schema = driver.getSchema
+      if (schema == null){
+        new Schema
+      }else{
+        schema
+      }
+    }
+  }
+
+  override def getThriftSchema = {
+    if(!isSharkQuery) {
+      new Schema
+    }else {
+      val schema = driver.getThriftSchema
+      if (schema == null){
+        new Schema
+      }else{
+        schema
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi

For a prototype we are working on, we needed to expose a JDBC/ODBC interface to Shark. I am submitting the initial cut of this code for integration onto the Shark codebase.
The changes to bin/shark and the scripts in bin/ext are very similar to hive's shell scripts and allow us to run either the shark server or cli as needed.
bin/shark brings up the command line as usual, whereas
bin/shark --service sharkserver brings up shark server on port 10000 by default
the shark server code itself is an extension of ThriftHive with simple extension points where we delegate to SharkDriver after the thrift deserialization is done.

The code has been tested by JDBC integration tests, as well as through integration with Tableau.
To test with Tableau, launch shark server, and download Tableau along with the Cloudera ODBC Hive connector. With this, Tableau can connect to Shark server via standard ODBC urls.
