### PR TITLE
Register Shark's conf variables with SessionState Configuration

### DIFF
--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -176,6 +176,8 @@ class SharkCliDriver extends CliDriver with LogHelper {
 
   private val conf: Configuration = if (ss != null) ss.getConf() else new Configuration()
 
+  SharkConfVars.initializeWithDefaults(conf);
+
   // Force initializing the SparkContext in SharkCliDriver object.
   SharkCliDriver.prompt
 

--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -23,6 +23,18 @@ object SharkConfVars {
 
   // If true, then query plans are compressed before being sent
   val COMPRESS_QUERY_PLAN = new ConfVar("shark.compressQueryPlan", true)
+
+  // Add Shark configuration variables and their default values to the given conf,
+  // so default values show up in 'set'.
+  def initializeWithDefaults(conf: Configuration) {
+    conf.set(EXEC_MODE.varname, EXEC_MODE.defaultVal)
+    conf.set(EXPLAIN_MODE.varname, EXPLAIN_MODE.defaultVal)
+
+    conf.setInt(COLUMN_INITIALSIZE.varname, COLUMN_INITIALSIZE.defaultIntVal)
+
+    conf.setBoolean(CHECK_TABLENAME_FLAG.varname, CHECK_TABLENAME_FLAG.defaultBoolVal)
+    conf.setBoolean(COMPRESS_QUERY_PLAN.varname, COMPRESS_QUERY_PLAN.defaultBoolVal)
+  }
   
   def getIntVar(conf: Configuration, variable: ConfVar): Int = {
     require(variable.valClass == classOf[Int])

--- a/src/main/scala/shark/SharkServer.scala
+++ b/src/main/scala/shark/SharkServer.scala
@@ -62,6 +62,8 @@ class SharkServerHandler extends HiveServerHandler with LogHelper {
 
   private val conf: Configuration = if (ss != null) ss.getConf() else new Configuration()
 
+  SharkConfVars.initializeWithDefaults(conf);
+
   private val driver = {
     val d = new SharkDriver(conf.asInstanceOf[HiveConf])
     d.init()


### PR DESCRIPTION
Previously, couldn't use "set <conf var>" to see default values of Shark's conf vars, which were also missing from "set;":

shark> set shark.explain.mode;
shark.explain.mode is undefined
