### PR TITLE
Updates based on Spark shuffle refractoring

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -10,7 +10,7 @@ object SharkBuild extends Build {
   val HADOOP_VERSION = "0.20.205.0"
 
   // Spark version to build against.
-  val SPARK_VERSION = "0.6.0"
+  val SPARK_VERSION = "0.7.0-SNAPSHOT"
 
   lazy val root = Project(
     id = "root",

--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -22,7 +22,7 @@ object SharkConfVars {
     if (System.getenv("MASTER") == null) 100 else -1)
 
   // Default storage level for cached tables.
-  val STORAGE_LEVEL = new ConfVar("shark.cache.storageLevel", "MEMORY_ONLY")
+  val STORAGE_LEVEL = new ConfVar("shark.cache.storageLevel", "MEMORY_AND_DISK")
 
   // If true, then cache any table whose name ends in "_cached".
   val CHECK_TABLENAME_FLAG = new ConfVar("shark.cache.flag.checkTableName", true)

--- a/src/main/scala/shark/execution/CoGroupedRDD.scala
+++ b/src/main/scala/shark/execution/CoGroupedRDD.scala
@@ -1,35 +1,24 @@
-package spark.rdd
+package spark
 
 import java.util.{HashMap => JHashMap}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
-import spark.Aggregator
-import spark.Dependency
-import spark.Logging
-import spark.OneToOneDependency
-import spark.Partitioner
-import spark.RDD
-import spark.ShuffleDependency
-import spark.SparkEnv
-import spark.Split
-
 // A version of CoGroupedRDD with the following changes:
 // - Disable map-side aggregation.
 // - Enforce return type to Array[ArrayBuffer].
 
-private[spark] sealed trait CoGroupSplitDep extends Serializable
-private[spark] case class NarrowCoGroupSplitDep(rdd: RDD[_], split: Split) extends CoGroupSplitDep
-private[spark] case class ShuffleCoGroupSplitDep(shuffleId: Int) extends CoGroupSplitDep
+sealed trait CoGroupSplitDep extends Serializable
+case class NarrowCoGroupSplitDep(rdd: RDD[_], split: Split) extends CoGroupSplitDep
+case class ShuffleCoGroupSplitDep(shuffleId: Int) extends CoGroupSplitDep
 
-private[spark]
 class CoGroupSplit(idx: Int, val deps: Seq[CoGroupSplitDep]) extends Split with Serializable {
   override val index: Int = idx
   override def hashCode(): Int = idx
 }
 
-private[spark] class CoGroupAggregator
+class CoGroupAggregator
   extends Aggregator[Any, Any, ArrayBuffer[Any]](
     { x => ArrayBuffer(x) },
     { (b, x) => b += x },

--- a/src/main/scala/shark/execution/GroupByPostShuffleOperator.scala
+++ b/src/main/scala/shark/execution/GroupByPostShuffleOperator.scala
@@ -22,7 +22,7 @@ import scala.reflect.BeanProperty
 
 import shark.execution.{HiveTopOperator, ReduceKey}
 import spark.{Aggregator, HashPartitioner, RDD}
-import spark.rdd.ShuffledAggregatedRDD
+import spark.rdd.ShuffledRDD
 import spark.SparkContext._
 
 
@@ -174,16 +174,12 @@ with HiveTopOperator {
     //rdd.asInstanceOf[RDD[(Any, Any)]].groupByKey(numReduceTasks)
 
     // TODO(rxin): Rewrite aggregation logic to integrate it with mergeValue.
-    val aggregator = new Aggregator[Any, Any, ArrayBuffer[Any]](
+    rdd.asInstanceOf[RDD[(Any, Any)]].combineByKey(
       GroupByAggregator.createCombiner _,
       GroupByAggregator.mergeValue _,
-      GroupByAggregator.mergeCombiners _,
+      null,
+      new HashPartitioner(numReduceTasks),
       false)
-
-    new ShuffledAggregatedRDD(
-      rdd.asInstanceOf[RDD[(Any, Any)]],
-      aggregator,
-      new HashPartitioner(numReduceTasks))
   }
 
   override def processPartition(split: Int, iter: Iterator[_]) = {
@@ -310,5 +306,4 @@ with HiveTopOperator {
 object GroupByAggregator {
   def createCombiner(v: Any) = ArrayBuffer(v)
   def mergeValue(buf: ArrayBuffer[Any], v: Any) = buf += v
-  def mergeCombiners(b1: ArrayBuffer[Any], b2: ArrayBuffer[Any]) = b1 ++= b2
 }

--- a/src/main/scala/shark/execution/JoinOperator.scala
+++ b/src/main/scala/shark/execution/JoinOperator.scala
@@ -13,8 +13,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
 import scala.reflect.BeanProperty
 
-import spark.{HashPartitioner, RDD}
-import spark.rdd.CoGroupedRDD
+import spark.{CoGroupedRDD, HashPartitioner, RDD}
 import spark.SparkContext._
 
 

--- a/src/main/scala/shark/execution/JoinOperator.scala
+++ b/src/main/scala/shark/execution/JoinOperator.scala
@@ -13,7 +13,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
 import scala.reflect.BeanProperty
 
-import spark.{CoGroupedRDD, HashPartitioner, RDD}
+import spark.{HashPartitioner, RDD}
+import spark.rdd.CoGroupedRDD
 import spark.SparkContext._
 
 


### PR DESCRIPTION
Passes the 43 groupby related tests from Hive from running
TEST=groupby TEST_FILE=src/test/tests_pass.txt bin/dev/test
