### PR TITLE
Initial cut for Shark-64

### DIFF
--- a/src/main/scala/shark/SharkCTAS.scala
+++ b/src/main/scala/shark/SharkCTAS.scala
@@ -1,37 +1,37 @@
 package shark
 
-import scala.collection.JavaConversions.asScalaBuffer
+import com.sun.org.apache.commons.logging.LogFactory
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.metadata.Hive
 import org.apache.hadoop.hive.ql.metadata.Table
-import com.sun.org.apache.commons.logging.LogFactory
+import scala.collection.JavaConversions.asScalaBuffer
 
 /**
  * Singleton representing access to the Shark Meta data that gets applied to cached tables
- * in the Hive Meta Store. 
+ * in the Hive Meta Store.
  * All cached tables are tagged with a property CTAS_QUERY_STRING whose value
  * represents the query that led to the creation of the cached table.
  * This is used to reload RDDs upon server restarts.
  */
 object SharkCTAS {
-  
+
   val db = Hive.get(new HiveConf)
-  
+
   val QUERY_STRING = "CTAS_QUERY_STRING"
-    
+
   private val LOG = LogFactory.getLog("SharkCTAS")
 
-  def loadAsRdds(cmdRunner : String => Unit): Unit = {
+  def loadAsRdds(cmdRunner: String => Unit): Unit = {
     getMeta.foreach(t => {
       try {
-      db.dropTable(t._1) 
-      cmdRunner(t._2)
-      }catch {
-      	case e:Exception => LOG.debug("Reloading cached table failed "+ t._1, e);
+        db.dropTable(t._1)
+        cmdRunner(t._2)
+      } catch {
+        case e: Exception => LOG.debug("Reloading cached table failed " + t._1, e);
       }
     })
   }
-  
+
   def updateMeta(cachedTableQueries : Iterable[(String,String)]): Unit = {
     cachedTableQueries.foreach(x => {
       val newTbl = new Table(db.getTable(x._1).getTTable())
@@ -39,7 +39,7 @@ object SharkCTAS {
       db.alterTable(x._1, newTbl)
     })
   }
-  
+
   def getMeta():Seq[(String, String)] = {
     db.getAllTables().foldLeft(List[(String,String)]())((curr, tableName) => {
       val tbl = db.getTable(tableName)
@@ -49,5 +49,5 @@ object SharkCTAS {
       }
     })
   }
- 
+
 }

--- a/src/main/scala/shark/SharkCTAS.scala
+++ b/src/main/scala/shark/SharkCTAS.scala
@@ -1,10 +1,10 @@
 package shark
 
 import scala.collection.JavaConversions.asScalaBuffer
-
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.metadata.Hive
 import org.apache.hadoop.hive.ql.metadata.Table
+import com.sun.org.apache.commons.logging.LogFactory
 
 /**
  * Singleton representing access to the Shark Meta data that gets applied to cached tables
@@ -18,11 +18,18 @@ object SharkCTAS {
   val db = Hive.get(new HiveConf)
   
   val QUERY_STRING = "CTAS_QUERY_STRING"
+    
+  private val LOG = LogFactory.getLog("SharkCTAS")
 
   def loadAsRdds(cmdRunner : String => Unit): Unit = {
+    println(getMeta)
     getMeta.foreach(t => {
+      try {
       db.dropTable(t._1) 
       cmdRunner(t._2)
+      }catch {
+      	case e:Exception => LOG.debug("Reloading cached table failed "+ t._1, e);
+      }
     })
   }
   

--- a/src/main/scala/shark/SharkCTAS.scala
+++ b/src/main/scala/shark/SharkCTAS.scala
@@ -1,0 +1,47 @@
+package shark
+
+import scala.collection.JavaConversions.asScalaBuffer
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.metadata.Hive
+import org.apache.hadoop.hive.ql.metadata.Table
+
+/**
+ * Singleton representing access to the Shark Meta data that gets applied to cached tables
+ * in the Hive Meta Store. 
+ * All cached tables are tagged with a property CTAS_QUERY_STRING whose value
+ * represents the query that led to the creation of the cached table.
+ * This is used to reload RDDs upon server restarts.
+ */
+object SharkCTAS {
+  
+  val db = Hive.get(new HiveConf)
+  
+  val QUERY_STRING = "CTAS_QUERY_STRING"
+
+  def loadAsRdds(cmdRunner : String => Unit): Unit = {
+    getMeta.foreach(t => {
+      db.dropTable(t._1) 
+      cmdRunner(t._2)
+    })
+  }
+  
+  def updateMeta(cachedTableQueries : Iterable[(String,String)]): Unit = {
+    cachedTableQueries.foreach(x => {
+      val newTbl = new Table(db.getTable(x._1).getTTable())
+      newTbl.setProperty(QUERY_STRING, x._2)
+      db.alterTable(x._1, newTbl)
+    })
+  }
+  
+  def getMeta():Seq[(String, String)] = {
+    db.getAllTables().foldLeft(List[(String,String)]())((curr, tableName) => {
+      val tbl = db.getTable(tableName)
+      Option(tbl.getProperty(QUERY_STRING)) match {
+        case Some(q) => curr.::(tableName, q)
+        case None => curr
+      }
+    })
+  }
+ 
+}

--- a/src/main/scala/shark/SharkCTAS.scala
+++ b/src/main/scala/shark/SharkCTAS.scala
@@ -22,7 +22,6 @@ object SharkCTAS {
   private val LOG = LogFactory.getLog("SharkCTAS")
 
   def loadAsRdds(cmdRunner : String => Unit): Unit = {
-    println(getMeta)
     getMeta.foreach(t => {
       try {
       db.dropTable(t._1) 

--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -212,6 +212,8 @@ class SharkCliDriver extends CliDriver with LogHelper {
   // Force initializing SharkEnv. This is put here but not object SharkCliDriver
   // because the Hive unit tests do not go through the main() code path.
   SharkEnv.init
+  
+  SharkCTAS.loadAsRdds(processCmd(_))
 
   override def processCmd(cmd: String): Int = {
     val ss: SessionState = SessionState.get()

--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -33,9 +33,10 @@ object SharkCliDriver {
   var prompt2 = "     " // when ';' is not yet seen.
 
   def main(args: Array[String]) {
-
+    val hiveArgs = args.filterNot(_.equals("-loadRdds"))
+    val loadRdds = hiveArgs.length < args.length
     val oproc = new OptionsProcessor()
-    if (!oproc.process_stage1(args)) {
+    if (!oproc.process_stage1(hiveArgs)) {
       System.exit(1)
     }
 
@@ -112,7 +113,7 @@ object SharkCliDriver {
       Thread.currentThread().setContextClassLoader(loader)
     }
 
-    var cli = new SharkCliDriver()
+    var cli = new SharkCliDriver(loadRdds)
 
     // Execute -i init files (always in silent mode)
     cli.processInitFiles(ss)
@@ -197,7 +198,7 @@ object SharkCliDriver {
 }
 
 
-class SharkCliDriver extends CliDriver with LogHelper {
+class SharkCliDriver(loadRdds:Boolean = false) extends CliDriver with LogHelper {
 
   private val ss = SessionState.get()
 
@@ -213,8 +214,10 @@ class SharkCliDriver extends CliDriver with LogHelper {
   // because the Hive unit tests do not go through the main() code path.
   SharkEnv.init
   
-  SharkCTAS.loadAsRdds(processCmd(_))
-
+  if(loadRdds) SharkCTAS.loadAsRdds(processCmd(_))
+  
+  def this() = this(false)
+  
   override def processCmd(cmd: String): Int = {
     val ss: SessionState = SessionState.get()
     val cmd_trimmed: String = cmd.trim()

--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -68,6 +68,7 @@ object SharkEnv extends LogHelper {
     // Stop the SparkContext
     if (SharkEnv.sc != null) {
       sc.stop()
+      sc = null
     }
   }
 

--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -65,12 +65,6 @@ object SharkEnv extends LogHelper {
   */
   def stop() {
     logInfo("Shutting down Shark Environment")
-    // Drop cached tables
-    val db = Hive.get(new HiveConf)
-    SharkEnv.cache.getAllKeyStrings foreach { key =>
-      logInfo("Dropping cached table " + key)
-      db.dropTable("default", key, false, true)
-    }
     // Stop the SparkContext
     if (SharkEnv.sc != null) {
       sc.stop()

--- a/src/main/scala/shark/memstore/CacheManager.scala
+++ b/src/main/scala/shark/memstore/CacheManager.scala
@@ -22,7 +22,7 @@ class CacheManager {
   def getAllKeyStrings(): Seq[String] = {
     keyToRdd.keys.map(_.key).collect { case k: String => k } toSeq
   }
-
+  //used for testing
   def drop(): Seq[String] = {
     val keys = getAllKeyStrings
     keyToRdd.clear

--- a/src/main/scala/shark/memstore/CacheManager.scala
+++ b/src/main/scala/shark/memstore/CacheManager.scala
@@ -23,4 +23,10 @@ class CacheManager {
     keyToRdd.keys.map(_.key).collect { case k: String => k } toSeq
   }
 
+  def drop(): Seq[String] = {
+    val keys = getAllKeyStrings
+    keyToRdd.clear
+    keyToStats.clear
+    keys
+  }
 }

--- a/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
@@ -2,7 +2,6 @@ package shark.parse
 
 import java.lang.reflect.Method
 import java.util.{ArrayList, List => JavaList}
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.api.{FieldSchema, MetaException}
@@ -13,16 +12,14 @@ import org.apache.hadoop.hive.ql.optimizer.Optimizer
 import org.apache.hadoop.hive.ql.parse._
 import org.apache.hadoop.hive.ql.plan._
 import org.apache.hadoop.hive.ql.session.SessionState
-
 import scala.collection.JavaConversions._
-
 import shark.{LogHelper, SharkConfVars, Utils}
 import shark.execution.{HiveOperator, Operator, OperatorFactory, ReduceSinkOperator, SparkWork,
   TerminalOperator}
 import shark.memstore.ColumnarSerDe
 import shark.SharkConfVars
+import shark.SharkCTAS
 import spark.storage.StorageLevel
-
 
 /**
  * Shark's version of Hive's SemanticAnalyzer. In SemanticAnalyzer,
@@ -160,6 +157,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
               case "MEMORY_AND_DISK_SER" => StorageLevel.MEMORY_AND_DISK_SER
               case "MEMORY_AND_DISK_SER_2" => StorageLevel.MEMORY_AND_DISK_SER_2
             }
+          qb.getTableDesc().getTblProps().put(SharkCTAS.QUERY_STRING, ctx.getCmd())
           OperatorFactory.createSharkCacheOutputPlan(
             hiveSinkOps.head, qb.getTableDesc.getTableName, storageLevel)
         } else if (pctx.getContext().asInstanceOf[QueryContext].useTableRddSink) {

--- a/src/test/scala/shark/SharkCTASSuite.scala
+++ b/src/test/scala/shark/SharkCTASSuite.scala
@@ -1,0 +1,40 @@
+package shark
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.metadata.Hive
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.FlatSpec
+import org.scalatest.FunSuite
+import scala.collection.JavaConversions._
+import org.scalatest.matchers.ShouldMatchers._
+import org.apache.hadoop.hive.ql.io.HiveInputFormat
+import org.apache.hadoop.hive.ql.io.HiveOutputFormat
+import org.scalatest.BeforeAndAfterAll
+
+class SharkCTASSuite extends FunSuite with BeforeAndAfterAll{
+
+  val db = Hive.get(new HiveConf)
+
+  override def beforeAll() {
+    db.createTable("test_cached",  List("foo"), List(), classOf[HiveInputFormat[_,_]], classOf[HiveOutputFormat[_,_]])
+    db.createTable("test2",  List("foo"), List(), classOf[HiveInputFormat[_,_]], classOf[HiveOutputFormat[_,_]])
+  }
+  
+  override def afterAll() {
+    db.dropTable("test_cached")
+    db.dropTable("test2")
+  }
+  
+  test("Initialize") {
+   
+    SharkCTAS.updateMeta(List(("test_cached","create table test_cached as select * from test"),
+        ("test2","create table test2_cached as select * from test")))
+    SharkCTAS.getMeta should have size (2)
+  }
+  test("Load Cached Tables") {
+     val cachedTables = List(("test_cached","create table test_cached as select * from test"),
+        ("test2","create table test2_cached as select * from test"))
+     SharkCTAS.updateMeta(cachedTables)
+     SharkCTAS.loadAsRdds(x => assert(cachedTables.exists(y => x.equals(y._2))))
+  }
+}

--- a/src/test/scala/shark/SharkCTASSuite.scala
+++ b/src/test/scala/shark/SharkCTASSuite.scala
@@ -16,24 +16,33 @@ class SharkCTASSuite extends FunSuite with BeforeAndAfterAll{
   val db = Hive.get(new HiveConf)
 
   override def beforeAll() {
-    db.createTable("test_cached",  List("foo"), List(), classOf[HiveInputFormat[_,_]], classOf[HiveOutputFormat[_,_]])
-    db.createTable("test2",  List("foo"), List(), classOf[HiveInputFormat[_,_]], classOf[HiveOutputFormat[_,_]])
+    db.createTable("foo2_cached",  
+    			    List("foo"),
+    			    List(),
+    			    classOf[HiveInputFormat[_,_]],
+    			    classOf[HiveOutputFormat[_,_]])
+    db.createTable("foo2", 
+                    List("foo"),
+                    List(), 
+                    classOf[HiveInputFormat[_,_]], 
+                    classOf[HiveOutputFormat[_,_]])
   }
   
   override def afterAll() {
-    db.dropTable("test_cached")
-    db.dropTable("test2")
+    db.dropTable("foo2_cached")
+    db.dropTable("foo2")
   }
   
   test("Initialize") {
+    val meta = List(("foo2_cached","create table foo2_cached as select * from test"),
+        ("foo2","create table foo2_cached as select * from test"))
    
-    SharkCTAS.updateMeta(List(("test_cached","create table test_cached as select * from test"),
-        ("test2","create table test2_cached as select * from test")))
-    SharkCTAS.getMeta should have size (2)
+    SharkCTAS.updateMeta(meta)
+    SharkCTAS.getMeta.containsAll(meta)
   }
   test("Load Cached Tables") {
-     val cachedTables = List(("test_cached","create table test_cached as select * from test"),
-        ("test2","create table test2_cached as select * from test"))
+     val cachedTables = List(("foo2_cached","create table foo2_cached as select * from test"),
+        ("foo2","create table foo2_cached as select * from test"))
      SharkCTAS.updateMeta(cachedTables)
      SharkCTAS.loadAsRdds(x => assert(cachedTables.exists(y => x.equals(y._2))))
   }

--- a/src/test/scala/shark/SharkServerSuite.scala
+++ b/src/test/scala/shark/SharkServerSuite.scala
@@ -5,30 +5,27 @@ import java.sql.DriverManager
 import java.sql.Statement
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
-
-import scala.actors.Actor
-import scala.collection.JavaConversions.asScalaConcurrentMap
-import scala.concurrent.ops.spawn
-
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.FunSuite
 import org.scalatest.matchers.ShouldMatchers
+import scala.actors.Actor
+import scala.collection.JavaConversions.asScalaConcurrentMap
+import scala.concurrent.ops.spawn
 
 class SharkServerSuite extends FunSuite with BeforeAndAfterAll  with BeforeAndAfterEach with ShouldMatchers {
 
   val WAREHOUSE_PATH = CliTestToolkit.getWarehousePath("server")
 
   val DRIVER_NAME  = "org.apache.hadoop.hive.jdbc.HiveDriver"
-  
+
   val TABLE = "test"
-  
+
   val CACHED_TBL_DESC = ("test_cached", "CREATE TABLE test_cached as select * from test")
 
   Class.forName(DRIVER_NAME)
-  
+
   override def beforeAll() {
-    
     launchServer()
     createTable
     createCachedTable
@@ -39,118 +36,114 @@ class SharkServerSuite extends FunSuite with BeforeAndAfterAll  with BeforeAndAf
     dropTable
     dropCachedTable
     SharkServer.stop
-    SharkEnv.stop
   }
-  
+
   def launchServer(args:Array[String] = Array[String]()) = {
     spawn {
       SharkServer.main(args)
     }
     while (!SharkServer.ready) {}
   }
-  
+
   test("Read from existing table") {
     val stmt = createStatement
     val rs = stmt.executeQuery("select count(*) from test where key = 406")
     stmt.close
-    rs.next ; 
+    rs.next
     val count = rs.getInt(1)
     count should equal (4)
-  } 
-  
+  }
+
   test("Read from existing cached table") {
     val stmt = createStatement
     val rs = stmt.executeQuery("select count(*) from test_cached where key = 406")
     stmt.close
-    rs.next ; 
+    rs.next
     val count = rs.getInt(1)
     count should equal (4)
-  } 
- 
+  }
+
   test("Shark-64, keep cache table metadata across sessions") {
     //drop cache, load rdds, and check if it worked
     SharkEnv.cache.drop
-  
-    def count = {
+    def count: Int = {
       val stmt = createStatement
       val rs = stmt.executeQuery("select count(*) from test_cached where key = 406")
       stmt.close
       rs.next;
       rs.getInt(1)
     }
-    
+
     SharkServer.stop
     launchServer()
-     
     count should equal (0)
     //stop and restart server, with explicit instruction to load RDDs
     SharkServer.stop
     launchServer(Array("-loadRdds"))
     count should equal (4)
-    
   }
-  
+
   test("Concurrent reads with state") {
     Class.forName(DRIVER_NAME)
     val n = 3
     val latch = new CountDownLatch(n)
     var results:collection.mutable.ConcurrentMap[Int, Int] = new ConcurrentHashMap[Int,Int]
     class ManagedReadActor(threshold:Int) extends Actor {
-          def exec = {
-            val con = getConnection
-            val setThresholdStmt = con.createStatement()
-            setThresholdStmt.executeQuery("set threshold = " + threshold)
-            val stmt = con.createStatement()
-            val rs = stmt.executeQuery("select  count(*) from test where key = " +
-              "${hiveconf:threshold}")
-            stmt.close
-            rs.next
-            val value = rs.getInt(1)
-            results.putIfAbsent(threshold, value)
-          }
-          
-          def act = {
-            try {
-              exec
-            }finally {
-              latch.countDown
-            }
-          }
+      def exec: Unit = {
+        val con = getConnection
+        val setThresholdStmt = con.createStatement()
+        setThresholdStmt.executeQuery("set threshold = " + threshold)
+        val stmt = con.createStatement()
+        val rs = stmt.executeQuery("select  count(*) from test where key = " +
+          "${hiveconf:threshold}")
+        stmt.close
+        rs.next
+        val value = rs.getInt(1)
+        results.putIfAbsent(threshold, value)
+      }
+
+      def act: Unit = {
+        try {
+          exec
+        } finally {
+          latch.countDown
+        }
+      }
     }
 
     List(238, 406, 401).foreach(index => new ManagedReadActor(index).start)
     latch.await
     results should be (Map[Int, Int](238 ->2, 406 -> 4, 401 -> 5))
   }
-  
+
   def getConnection:Connection  = DriverManager.getConnection("jdbc:hive://localhost:10000/default", "", "")
-  
+
   def createStatement:Statement = {
     getConnection.createStatement()
   }
-  
-  def createTable() = {
+
+  def createTable(): Unit = {
     val dataFilePath = System.getenv("HIVE_DEV_HOME") + "/data/files/kv1.txt"
     val stmt = createStatement
     stmt.executeQuery("DROP TABLE IF EXISTS test")
     stmt.executeQuery("CREATE TABLE test(key int, val string)")
-    stmt.executeQuery("LOAD DATA LOCAL INPATH '" + dataFilePath+ "' OVERWRITE INTO TABLE test")
+    stmt.executeQuery("LOAD DATA LOCAL INPATH '" + dataFilePath + "' OVERWRITE INTO TABLE test")
     stmt.close
   }
-  
-  def createCachedTable() = {
+
+  def createCachedTable(): Unit = {
     val stmt = createStatement
     stmt.executeQuery("DROP TABLE IF EXISTS test_cached")
     createStatement.executeQuery(CACHED_TBL_DESC._2)
     stmt.close
   }
-  
-  def dropTable(implicit table:String = TABLE) = {
+
+  def dropTable(implicit table:String = TABLE): Unit = {
     val stmt = createStatement
-    val sql = "DROP TABLE " + table 
+    val sql = "DROP TABLE " + table
     val rs = stmt.executeQuery(sql)
     stmt.close
   }
-  
+
   def dropCachedTable = dropTable(TABLE + "_cached")
 }

--- a/src/test/scala/shark/SharkServerSuite.scala
+++ b/src/test/scala/shark/SharkServerSuite.scala
@@ -20,52 +20,74 @@ class SharkServerSuite extends FunSuite with BeforeAndAfterAll  with BeforeAndAf
   val WAREHOUSE_PATH = CliTestToolkit.getWarehousePath("server")
 
   val DRIVER_NAME  = "org.apache.hadoop.hive.jdbc.HiveDriver"
+  
   val TABLE = "test"
+  
+  val CACHED_TBL_DESC = ("test_cached", "CREATE TABLE test_cached as select * from test")
 
   Class.forName(DRIVER_NAME)
   
   override def beforeAll() {
     
-    spawn {
-      SharkServer.main(Array[String]())
-    }
-    while(!SharkServer.ready){}
+    launchServer()
     createTable
     createCachedTable
   }
 
   override def afterAll() {
+
     dropTable
     dropCachedTable
     SharkServer.stop
+    SharkEnv.stop
+  }
+  
+  def launchServer(args:Array[String] = Array[String]()) = {
+    spawn {
+      SharkServer.main(args)
+    }
+    while (!SharkServer.ready) {}
   }
   
   test("Read from existing table") {
     val stmt = createStatement
     val rs = stmt.executeQuery("select count(*) from test where key = 406")
+    stmt.close
     rs.next ; 
     val count = rs.getInt(1)
-    println("Count : " , count)
     count should equal (4)
   } 
   
   test("Read from existing cached table") {
     val stmt = createStatement
     val rs = stmt.executeQuery("select count(*) from test_cached where key = 406")
+    stmt.close
     rs.next ; 
     val count = rs.getInt(1)
     count should equal (4)
   } 
  
-  test("SHARK-64, persist cached table metadata across sessions" ) {
-    //cached table creation in the initialization step should have attached metadata
-    assert(SharkCTAS.getMeta.exists(x => x._1.equalsIgnoreCase("test_cached")))
-    dropTable("test_cached")
-    assert(!SharkCTAS.getMeta.exists(x => x._1.equalsIgnoreCase("test_cached")))
-    createCachedTable
-    //check the tables have been recreated
-    assert(SharkCTAS.getMeta.exists(x => x._1.equalsIgnoreCase("test_cached")))
-
+  test("Shark-64, keep cache table metadata across sessions") {
+    //drop cache, load rdds, and check if it worked
+    SharkEnv.cache.drop
+  
+    def count = {
+      val stmt = createStatement
+      val rs = stmt.executeQuery("select count(*) from test_cached where key = 406")
+      stmt.close
+      rs.next;
+      rs.getInt(1)
+    }
+    
+    SharkServer.stop
+    launchServer()
+     
+    count should equal (0)
+    //stop and restart server, with explicit instruction to load RDDs
+    SharkServer.stop
+    launchServer(Array("-loadRdds"))
+    count should equal (4)
+    
   }
   
   test("Concurrent reads with state") {
@@ -81,7 +103,7 @@ class SharkServerSuite extends FunSuite with BeforeAndAfterAll  with BeforeAndAf
             val stmt = con.createStatement()
             val rs = stmt.executeQuery("select  count(*) from test where key = " +
               "${hiveconf:threshold}")
-            
+            stmt.close
             rs.next
             val value = rs.getInt(1)
             results.putIfAbsent(threshold, value)
@@ -113,18 +135,21 @@ class SharkServerSuite extends FunSuite with BeforeAndAfterAll  with BeforeAndAf
     stmt.executeQuery("DROP TABLE IF EXISTS test")
     stmt.executeQuery("CREATE TABLE test(key int, val string)")
     stmt.executeQuery("LOAD DATA LOCAL INPATH '" + dataFilePath+ "' OVERWRITE INTO TABLE test")
+    stmt.close
   }
   
   def createCachedTable() = {
     val stmt = createStatement
     stmt.executeQuery("DROP TABLE IF EXISTS test_cached")
-    createStatement.executeQuery("CREATE TABLE test_cached as select * from test")
+    createStatement.executeQuery(CACHED_TBL_DESC._2)
+    stmt.close
   }
   
   def dropTable(implicit table:String = TABLE) = {
     val stmt = createStatement
     val sql = "DROP TABLE " + table 
     val rs = stmt.executeQuery(sql)
+    stmt.close
   }
   
   def dropCachedTable = dropTable(TABLE + "_cached")

--- a/src/test/scala/shark/SharkServerSuite.scala
+++ b/src/test/scala/shark/SharkServerSuite.scala
@@ -1,61 +1,131 @@
 package shark
 
-import java.io.{BufferedReader, InputStreamReader, PrintWriter}
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.Statement
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
 
-class SharkServerSuite extends FunSuite with BeforeAndAfterAll with CliTestToolkit {
+import scala.actors.Actor
+import scala.collection.JavaConversions.asScalaConcurrentMap
+import scala.concurrent.ops.spawn
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.FunSuite
+import org.scalatest.matchers.ShouldMatchers
+
+class SharkServerSuite extends FunSuite with BeforeAndAfterAll  with BeforeAndAfterEach with ShouldMatchers {
 
   val WAREHOUSE_PATH = CliTestToolkit.getWarehousePath("server")
 
-  var serverProcess : Process = null
-  var serverInputReader : BufferedReader = null
-  var serverErrorReader : BufferedReader = null
+  val DRIVER_NAME  = "org.apache.hadoop.hive.jdbc.HiveDriver"
+  val TABLE = "test"
 
+  Class.forName(DRIVER_NAME)
+  
   override def beforeAll() {
-    val serverPb = new ProcessBuilder("./bin/shark", "--service", "sharkserver")
-    val serverEnv = serverPb.environment()
-    serverEnv.put("SHARK_LAUNCH_WITH_JAVA", "1")
-    serverProcess = serverPb.start()
-    serverInputReader = new BufferedReader(new InputStreamReader(serverProcess.getInputStream))
-    serverErrorReader = new BufferedReader(new InputStreamReader(serverProcess.getErrorStream))
-    Thread.sleep(5000)
-
-    val clientPb = new ProcessBuilder("./bin/shark", "-h", "localhost")
-    process = clientPb.start()
-    outputWriter = new PrintWriter(process.getOutputStream, true)
-    inputReader = new BufferedReader(new InputStreamReader(process.getInputStream))
-    errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream))
-    waitForOutput(inputReader, "shark>")
-    outputWriter.write("set hive.metastore.warehouse.dir=" + WAREHOUSE_PATH + ";\n")
-    outputWriter.flush()
-    waitForOutput(inputReader, "shark>")
+    
+    spawn {
+      SharkServer.main(Array[String]())
+    }
+    while(!SharkServer.ready){}
+    createTable
+    createCachedTable
   }
 
   override def afterAll() {
-    process.destroy()
-    process.waitFor()
-    serverProcess.destroy()
-    serverProcess.waitFor()
+    dropTable
+    dropCachedTable
+    SharkServer.stop
   }
+  
+  test("Read from existing table") {
+    val stmt = createStatement
+    val rs = stmt.executeQuery("select count(*) from test where key = 406")
+    rs.next ; 
+    val count = rs.getInt(1)
+    println("Count : " , count)
+    count should equal (4)
+  } 
+  
+  test("Read from existing cached table") {
+    val stmt = createStatement
+    val rs = stmt.executeQuery("select count(*) from test_cached where key = 406")
+    rs.next ; 
+    val count = rs.getInt(1)
+    count should equal (4)
+  } 
+ 
+  test("SHARK-64, persist cached table metadata across sessions" ) {
+    //cached table creation in the initialization step should have attached metadata
+    assert(SharkCTAS.getMeta.exists(x => x._1.equalsIgnoreCase("test_cached")))
+    dropTable("test_cached")
+    assert(!SharkCTAS.getMeta.exists(x => x._1.equalsIgnoreCase("test_cached")))
+    createCachedTable
+    //check the tables have been recreated
+    assert(SharkCTAS.getMeta.exists(x => x._1.equalsIgnoreCase("test_cached")))
 
-  override def waitForQuery(timeout: Long) : String = {
-    if (waitForOutput(serverErrorReader, "OK", timeout)) {
-      Thread.sleep(1000)
-      return readOutput()
-    } else {
-      assert(false)
-      return null
+  }
+  
+  test("Concurrent reads with state") {
+    Class.forName(DRIVER_NAME)
+    val n = 3
+    val latch = new CountDownLatch(n)
+    var results:collection.mutable.ConcurrentMap[Int, Int] = new ConcurrentHashMap[Int,Int]
+    class ManagedReadActor(threshold:Int) extends Actor {
+          def exec = {
+            val con = getConnection
+            val setThresholdStmt = con.createStatement()
+            setThresholdStmt.executeQuery("set threshold = " + threshold)
+            val stmt = con.createStatement()
+            val rs = stmt.executeQuery("select  count(*) from test where key = " +
+              "${hiveconf:threshold}")
+            
+            rs.next
+            val value = rs.getInt(1)
+            results.putIfAbsent(threshold, value)
+          }
+          
+          def act = {
+            try {
+              exec
+            }finally {
+              latch.countDown
+            }
+          }
     }
-  }
 
-  test("Simple Query against Shark Server") {
+    List(238, 406, 401).foreach(index => new ManagedReadActor(index).start)
+    latch.await
+    results should be (Map[Int, Int](238 ->2, 406 -> 4, 401 -> 5))
+  }
+  
+  def getConnection:Connection  = DriverManager.getConnection("jdbc:hive://localhost:10000/default", "", "")
+  
+  def createStatement:Statement = {
+    getConnection.createStatement()
+  }
+  
+  def createTable() = {
     val dataFilePath = System.getenv("HIVE_DEV_HOME") + "/data/files/kv1.txt"
-    executeQuery("drop table if exists test;");
-    executeQuery("create table test(key int, val string);")
-    executeQuery("load data local inpath '" + dataFilePath+ "' overwrite into table test;")
-    val out = executeQuery("select * from test where key = 407;")
-    assert(out.contains("val_407"))
-    //executeQuery("exit;")
+    val stmt = createStatement
+    stmt.executeQuery("DROP TABLE IF EXISTS test")
+    stmt.executeQuery("CREATE TABLE test(key int, val string)")
+    stmt.executeQuery("LOAD DATA LOCAL INPATH '" + dataFilePath+ "' OVERWRITE INTO TABLE test")
   }
-
+  
+  def createCachedTable() = {
+    val stmt = createStatement
+    stmt.executeQuery("DROP TABLE IF EXISTS test_cached")
+    createStatement.executeQuery("CREATE TABLE test_cached as select * from test")
+  }
+  
+  def dropTable(implicit table:String = TABLE) = {
+    val stmt = createStatement
+    val sql = "DROP TABLE " + table 
+    val rs = stmt.executeQuery(sql)
+  }
+  
+  def dropCachedTable = dropTable(TABLE + "_cached")
 }


### PR DESCRIPTION
https://spark-project.atlassian.net/browse/SHARK-64
This checkin fixes Shark-64.
When cached tables are created, meta data is added to the hive meta store for each table, that includes the query that resulted in the cached table creation.
Upon server restarts, we run through the queries to re populate the cached RDDs before resuming work.
Also added a few JDBC tests for Shark Server
