### PR TITLE
Adding TaskContext to compute methods in Shark RDDs (patch by Thomas Dudziak)

### DIFF
--- a/src/main/scala/shark/execution/CoGroupedRDD.scala
+++ b/src/main/scala/shark/execution/CoGroupedRDD.scala
@@ -91,7 +91,7 @@ class CoGroupedRDD[K](@transient rdds: Seq[RDD[(_, _)]], part: Partitioner)
 
   override def preferredLocations(s: Split) = Nil
 
-  override def compute(s: Split): Iterator[(K, Array[ArrayBuffer[Any]])] = {
+  override def compute(s: Split, context: TaskContext): Iterator[(K, Array[ArrayBuffer[Any]])] = {
     val split = s.asInstanceOf[CoGroupSplit]
     val numRdds = split.deps.size
     val map = new JHashMap[K, Array[ArrayBuffer[Any]]]
@@ -106,7 +106,7 @@ class CoGroupedRDD[K](@transient rdds: Seq[RDD[(_, _)]], part: Partitioner)
     for ((dep, depNum) <- split.deps.zipWithIndex) dep match {
       case NarrowCoGroupSplitDep(rdd, itsSplit) => {
         // Read them from the parent
-        for ((k, v) <- rdd.iterator(itsSplit)) { getSeq(k.asInstanceOf[K])(depNum) += v }
+        for ((k, v) <- rdd.iterator(itsSplit, context)) { getSeq(k.asInstanceOf[K])(depNum) += v }
       }
       case ShuffleCoGroupSplitDep(shuffleId) => {
         // Read map outputs of shuffle

--- a/src/main/scala/shark/execution/EnhancedRDD.scala
+++ b/src/main/scala/shark/execution/EnhancedRDD.scala
@@ -46,5 +46,5 @@ class SplitsPruningRDD[T: ClassManifest](
 
   override def splits = _splits
   override val dependencies = List(new OneToOneDependency(prev))
-  override def compute(split: Split) = prev.iterator(split)
+  override def compute(split: Split, context: TaskContext) = prev.iterator(split, context)
 }

--- a/src/main/scala/shark/execution/TableRDD.scala
+++ b/src/main/scala/shark/execution/TableRDD.scala
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector
 
 import shark.execution.serialization.KryoSerializer
 
-import spark.{OneToOneDependency, RDD, Split}
+import spark.{OneToOneDependency, RDD, Split, TaskContext}
 
 
 /**
@@ -138,7 +138,7 @@ case class TableRDD(
 
   override val dependencies = List(new OneToOneDependency(prev))
 
-  override def compute(split: Split) = prev.iterator(split)
+  override def compute(split: Split, context: TaskContext) = prev.iterator(split, context)
 
   /**
    * Initialize object inspector from the serializedObjectInspector.


### PR DESCRIPTION
This is necessary for Shark to build against the Spark master branch.
