### PR TITLE
Java API

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -90,7 +90,8 @@ object SharkBuild extends Build {
       "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION,
       "it.unimi.dsi" % "fastutil" % "6.4.2",
       "org.scalatest" %% "scalatest" % "1.9.1" % "test",
-      "junit" % "junit" % "4.10" % "test") ++
+      "junit" % "junit" % "4.10" % "test",
+      "com.novocode" % "junit-interface" % "0.8" % "test") ++
       (if (TACHYON_ENABLED) Some("org.tachyonproject" % "tachyon" % "0.2.1") else None).toSeq
 
   ) ++ assemblySettings ++ Seq(test in assembly := {}) ++ Seq(getClassPathTask)

--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -19,6 +19,7 @@ package shark
 
 import scala.collection.mutable.{HashMap, HashSet}
 
+import shark.api.JavaSharkContext
 import shark.memstore2.MemoryMetadataManager
 import shark.tachyon.TachyonUtilImpl
 import spark.SparkContext
@@ -54,6 +55,27 @@ object SharkEnv extends LogHelper {
         executorEnvVars)
     sc.addSparkListener(new StatsReportListener())
     sc.asInstanceOf[SharkContext]
+  }
+
+  def initWithSharkContext(newSc: SharkContext): SharkContext = {
+    if (sc != null) {
+      sc.stop
+    }
+
+    sc = newSc
+    sc.asInstanceOf[SharkContext]
+  }
+
+  def initWithJavaSharkContext(jobName: String): JavaSharkContext = {
+    new JavaSharkContext(initWithSharkContext(jobName))
+  }
+
+  def initWithJavaSharkContext(jobName: String, master: String): JavaSharkContext = {
+    new JavaSharkContext(initWithSharkContext(jobName, master))
+  }
+
+  def initWithJavaSharkContext(newSc: JavaSharkContext): JavaSharkContext = {
+    new JavaSharkContext(initWithSharkContext(newSc.sharkCtx))
   }
 
   logInfo("Initializing SharkEnv")

--- a/src/main/scala/shark/api/JavaSharkContext.scala
+++ b/src/main/scala/shark/api/JavaSharkContext.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.api
+
+import java.util.{Map => JMap}
+import java.util.{List => JList}
+
+import scala.collection.JavaConversions._
+
+import spark.api.java.JavaSparkContext
+import shark.SharkContext
+
+class JavaSharkContext(val sharkCtx: SharkContext) extends JavaSparkContext(sharkCtx) {
+
+  /**
+   * @param master Cluster URL to connect to (e.g. mesos://host:port, spark://host:port, local[4]).
+   * @param jobName A name for your job, to display on the cluster web UI
+   */
+  def this(master: String, jobName: String) = this(new SharkContext(master, jobName, null, Nil, Map.empty))
+
+  /**
+   * @param master Cluster URL to connect to (e.g. mesos://host:port, spark://host:port, local[4]).
+   * @param jobName A name for your job, to display on the cluster web UI
+   * @param sparkHome The SPARK_HOME directory on the slave nodes
+   * @param jarFile A JAR to send to the cluster. This can be a path on the local file
+   *                system or a HDFS, HTTP, HTTPS, or FTP URL.
+   */
+  def this(master: String, jobName: String, sparkHome: String, jarFile: String) =
+    this(new SharkContext(master, jobName, sparkHome, Seq(jarFile), Map.empty))
+
+  /**
+   * @param master Cluster URL to connect to (e.g. mesos://host:port, spark://host:port, local[4]).
+   * @param jobName A name for your job, to display on the cluster web UI
+   * @param sparkHome The SPARK_HOME directory on the slave nodes
+   * @param jars Collection of JARs to send to the cluster. These can be paths on the local file
+   *             system or HDFS, HTTP, HTTPS, or FTP URLs.
+   */
+  def this(master: String, jobName: String, sparkHome: String, jars: Array[String]) =
+    this(new SharkContext(master, jobName, sparkHome, jars.toSeq, Map.empty))
+
+  /**
+   * @param master Cluster URL to connect to (e.g. mesos://host:port, spark://host:port, local[4]).
+   * @param jobName A name for your job, to display on the cluster web UI
+   * @param sparkHome The SPARK_HOME directory on the slave nodes
+   * @param jars Collection of JARs to send to the cluster. These can be paths on the local file
+   *             system or HDFS, HTTP, HTTPS, or FTP URLs.
+   * @param environment Environment variables to set on worker nodes
+   */
+  def this(master: String, jobName: String, sparkHome: String, jars: Array[String],
+           environment: JMap[String, String]) =
+    this(new SharkContext(master, jobName, sparkHome, jars.toSeq, environment))
+
+  /**
+   * Execute the command and return the results as a sequence. Each element
+   * in the sequence is one row.
+   */
+  def sql(cmd: String): JList[String] = sharkCtx.sql(cmd)
+
+  /**
+   * Execute the command and return the results as a TableRDD.
+   */
+  def sql2rdd(cmd: String): JavaTableRDD = {
+    val rdd = sharkCtx.sql2rdd(cmd)
+    new JavaTableRDD(rdd, rdd.schema)
+  }
+
+  /**
+   * Execute the command and print the results to the console.
+   */
+  def sql2console(cmd: String) {
+    sharkCtx.sql2console(cmd)
+  }
+}

--- a/src/main/scala/shark/api/JavaTableRDD.scala
+++ b/src/main/scala/shark/api/JavaTableRDD.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.api
+
+import spark.api.java.function.{Function => JFunction}
+import spark.api.java.JavaRDDLike
+import spark.RDD
+import spark.storage.StorageLevel
+
+import java.util.{List => JavaList}
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema
+
+class JavaTableRDD(val rdd: RDD[Row], val schema: JavaList[FieldSchema]) extends JavaRDDLike[Row, JavaTableRDD] {
+
+  override def wrapRDD(rdd: RDD[Row]): JavaTableRDD = new JavaTableRDD(rdd, schema)
+
+  // Common RDD functions
+  override val classManifest: ClassManifest[Row] = implicitly[ClassManifest[Row]]
+
+  // This shouldn't be necessary, but we seem to need this to get first() to return Row
+  // instead of Object; possibly a compiler bug?
+  override def first(): Row = rdd.first()
+
+  /** Persist this RDD with the default storage level (`MEMORY_ONLY`). */
+  def cache(): JavaTableRDD = wrapRDD(rdd.cache())
+
+  /**
+   * Set this RDD's storage level to persist its values across operations after the first time
+   * it is computed. Can only be called once on each RDD.
+   */
+  def persist(newLevel: StorageLevel): JavaTableRDD = wrapRDD(rdd.persist(newLevel))
+
+  // Transformations (return a new RDD)
+
+  // Note: we didn't implement distinct() because equals() and hashCode() are not defined for Row.
+
+  /**
+   * Return a new RDD containing only the elements that satisfy a predicate.
+   */
+  def filter(f: JFunction[Row, java.lang.Boolean]): JavaTableRDD =
+    wrapRDD(rdd.filter((x => f(x).booleanValue())))
+
+  /**
+   * Return a sampled subset of this RDD.
+   */
+  def sample(withReplacement: Boolean, fraction: Double, seed: Int): JavaTableRDD =
+    wrapRDD(rdd.sample(withReplacement, fraction, seed))
+
+  /**
+   * Return the union of this RDD and another one. Any identical elements will appear multiple
+   * times (use `.distinct()` to eliminate them).
+   *
+   * Note: the `schema` of a union is this RDD's schema.
+   */
+  def union(other: JavaTableRDD): JavaTableRDD = wrapRDD(rdd.union(other.rdd))
+
+}
+
+

--- a/src/test/java/shark/JavaAPISuite.java
+++ b/src/test/java/shark/JavaAPISuite.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import spark.api.java.JavaRDD;
+import spark.api.java.function.Function;
+
+import shark.api.Row;
+import shark.api.JavaSharkContext;
+import shark.api.JavaTableRDD;
+
+import java.io.Serializable;
+import java.util.List;
+
+// The test suite itself is Serializable so that anonymous Function implementations can be
+// serialized, as an alternative to converting these anonymous classes to static inner classes;
+// see http://stackoverflow.com/questions/758570/.
+public class JavaAPISuite implements Serializable {
+
+    private static final String WAREHOUSE_PATH = CliTestToolkit$.MODULE$.getWarehousePath("JavaAPISuite");
+    private static final String METASTORE_PATH = CliTestToolkit$.MODULE$.getMetastorePath("JavaAPISuite");
+
+    private static transient JavaSharkContext sc;
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        sc = SharkEnv.initWithJavaSharkContext("JavaAPISuite", "local");
+        sc.sql("set javax.jdo.option.ConnectionURL=jdbc:derby:;databaseName=" +
+                METASTORE_PATH + ";create=true");
+        sc.sql("set hive.metastore.warehouse.dir=" + WAREHOUSE_PATH);
+        sc.sql("set shark.test.data.path=" + CliTestToolkit$.MODULE$.dataFilePath());
+
+        // test
+        sc.sql("CREATE TABLE test (key INT, val STRING)");
+        sc.sql("LOAD DATA LOCAL INPATH '${hiveconf:shark.test.data.path}/kv1.txt' INTO TABLE test");
+        sc.sql("CREATE TABLE test_cached AS SELECT * FROM test");
+
+        // users
+        sc.sql("create table users (id int, name string) row format delimited fields terminated by '\t'");
+        sc.sql("load data local inpath '${hiveconf:shark.test.data.path}/users.txt' OVERWRITE INTO TABLE users");
+        sc.sql("create table users_cached as select * from users");
+    }
+
+    @AfterClass
+    public static void oneTimeTearDown() {
+        sc.stop();
+    }
+
+    @Test
+    public void selectQuery() {
+        List<String> result = sc.sql("select val from test");
+        Assert.assertEquals(500, result.size());
+        Assert.assertTrue(result.contains("val_407"));
+    }
+
+    @Test
+    public void sql2rdd() {
+        JavaTableRDD result = sc.sql2rdd("select val from test");
+        JavaRDD<String> values = result.map(new Function<Row, String>() {
+            @Override
+            public String call(Row x) {
+                return x.getString(0);
+            }
+        });
+        Assert.assertEquals(500, values.count());
+        Assert.assertTrue(values.collect().contains("val_407"));
+    }
+
+    @Test
+    public void filter() {
+        JavaTableRDD result = sc.sql2rdd("select * from users");
+        JavaTableRDD filtered = result.filter(new Function<Row, Boolean>() {
+            @Override
+            public Boolean call(Row row) throws Exception {
+                return row.getString("name").equals("B");
+            }
+        }).cache();
+        Assert.assertEquals(1, filtered.count());
+        Assert.assertEquals(2, filtered.first().getInt("id").intValue());
+    }
+
+    @Test
+    public void union() {
+        JavaTableRDD a = sc.sql2rdd("select * from users where name = \"A\"");
+        JavaTableRDD b = sc.sql2rdd("select * from users where name = \"B\"");
+        JavaTableRDD union = a.union(b);
+        Assert.assertEquals(3, union.count());
+        List<String> uniqueNames = union.map(new Function<Row, String>() {
+            @Override
+            public String call(Row row) throws Exception {
+                return row.getString("name");
+            }
+        }).distinct().collect();
+        Assert.assertEquals(2, uniqueNames.size());
+    }
+
+}


### PR DESCRIPTION
This pull request adds a basic Java API to Shark ([SHARK-115](https://spark-project.atlassian.net/browse/SHARK-115)).  The implementation is essentially a pair of thin wrappers around `SharkContext` and `TabledRDD` to implement the `JavaSparkContext` and `JavaRDDLike` APIs.
