### PR TITLE
Shark-146 map join fails due to task result bigger than Akka frame size

### DIFF
--- a/src/main/scala/shark/execution/MapJoinOperator.scala
+++ b/src/main/scala/shark/execution/MapJoinOperator.scala
@@ -126,6 +126,10 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
 
       // Collect the RDD and build a hash table.
       val startCollect = System.currentTimeMillis()
+      if (rddForHash.getStorageLevel == StorageLevel.NONE) {
+        rddForHash.persist()
+      }
+      rddForHash.foreach(_ => Unit)
       val wrappedRows = rddForHash.partitions.flatMap { part => 
         val iter = SparkEnv.get.blockManager.get("rdd_%s_%s".format(rddForHash.id, part.index))
         val partRows = new ArrayBuffer[(Seq[AnyRef], Seq[Array[AnyRef]])]


### PR DESCRIPTION
creating blocks for small table and put them in block manager on slave workers, use block manager to fetch the blocks
