### PR TITLE
Compressing Columns Stored in Memory

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -39,6 +39,7 @@ object SharkBuild extends Build {
     id = "root",
     base = file("."),
     settings = coreSettings)
+    .settings(net.virtualvoid.sbt.graph.Plugin.graphSettings: _*)
 
   def coreSettings = Defaults.defaultSettings ++ Seq(
 
@@ -59,8 +60,8 @@ object SharkBuild extends Build {
     ),
 
     fork := true,
-    javaOptions in test += "-XX:MaxPermSize=512m",
-    javaOptions in test += "-Xmx2g",
+    javaOptions += "-XX:MaxPermSize=512m",
+    javaOptions += "-Xmx12g",
 
     testListeners <<= target.map(
       t => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath))),
@@ -92,6 +93,7 @@ object SharkBuild extends Build {
       "com.google.guava" % "guava" % "11.0.1",
       "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION,
       "com.ning" % "compress-lzf" % "0.9.7",
+      "com.google.caliper" % "caliper" % "1.0-beta-1" % "test",
       "it.unimi.dsi" % "fastutil" % "6.4.2",
       "org.scalatest" %% "scalatest" % "1.9.1" % "test",
       "junit" % "junit" % "4.10" % "test",

--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -91,6 +91,7 @@ object SharkBuild extends Build {
       "org.spark-project" %% "spark-repl" % SPARK_VERSION,
       "com.google.guava" % "guava" % "11.0.1",
       "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION,
+      "com.ning" % "compress-lzf" % "0.9.7",
       "it.unimi.dsi" % "fastutil" % "6.4.2",
       "org.scalatest" %% "scalatest" % "1.9.1" % "test",
       "junit" % "junit" % "4.10" % "test",

--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -61,7 +61,7 @@ object SharkBuild extends Build {
 
     fork := true,
     javaOptions += "-XX:MaxPermSize=512m",
-    javaOptions += "-Xmx12g",
+    javaOptions += "-Xmx2g",
 
     testListeners <<= target.map(
       t => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath))),
@@ -93,7 +93,6 @@ object SharkBuild extends Build {
       "com.google.guava" % "guava" % "11.0.1",
       "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION,
       "com.ning" % "compress-lzf" % "0.9.7",
-      "com.google.caliper" % "caliper" % "1.0-beta-1" % "test",
       "it.unimi.dsi" % "fastutil" % "6.4.2",
       "org.scalatest" %% "scalatest" % "1.9.1" % "test",
       "junit" % "junit" % "4.10" % "test",

--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -63,6 +63,8 @@ object SharkBuild extends Build {
     javaOptions += "-XX:MaxPermSize=512m",
     javaOptions += "-Xmx2g",
 
+    testOptions in Test += Tests.Argument("-oF"), // Full stack trace on test failures
+
     testListeners <<= target.map(
       t => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath))),
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,6 +15,8 @@
 
 addSbtPlugin("org.ensime" % "ensime-sbt-cmd" % "0.1.1")
 
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.3")
+
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")

--- a/run
+++ b/run
@@ -88,6 +88,7 @@ else
   else
     echo "Cannot find either compiled classes or compiled jar package for Shark."
     echo "Have you compiled Shark yet?"
+    echo "Looking in $SPARK_CLASSPATH and $SHARK_JAR and $SHARK_CLASSES"
     exit 1
   fi
 fi
@@ -155,4 +156,5 @@ if [ "x$RUNNER" == "x" ] ; then
   fi
 fi
 
+echo "$RUNNER $EXTRA_ARGS $@"
 exec $RUNNER $EXTRA_ARGS "$@"

--- a/run
+++ b/run
@@ -156,5 +156,4 @@ if [ "x$RUNNER" == "x" ] ; then
   fi
 fi
 
-echo "$RUNNER $EXTRA_ARGS $@"
 exec $RUNNER $EXTRA_ARGS "$@"

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -121,5 +121,4 @@ loadConfigFile() {
 [[ -f "$etc_sbt_opts_file" ]] && set -- $(loadConfigFile "$etc_sbt_opts_file") "$@"
 [[ -f "$sbt_opts_file" ]] && set -- $(loadConfigFile "$sbt_opts_file") "$@"
 
-echo $java_opts
 run "$@"

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -121,4 +121,5 @@ loadConfigFile() {
 [[ -f "$etc_sbt_opts_file" ]] && set -- $(loadConfigFile "$etc_sbt_opts_file") "$@"
 [[ -f "$sbt_opts_file" ]] && set -- $(loadConfigFile "$sbt_opts_file") "$@"
 
+echo $java_opts
 run "$@"

--- a/sbt/sbt-launch-lib.bash
+++ b/sbt/sbt-launch-lib.bash
@@ -140,16 +140,6 @@ run() {
   set -- "${residual_args[@]}"
   argumentCount=$#
 
-
-  echo "$java_cmd" \
-    ${SBT_OPTS:-$default_sbt_opts} \
-    $(get_mem_opts $sbt_mem) \
-    ${java_opts} \
-    ${java_args[@]} \
-    -jar "$sbt_jar" \
-    "${sbt_commands[@]}" \
-    "${residual_args[@]}"
-
   # run sbt
   execRunner "$java_cmd" \
     ${SBT_OPTS:-$default_sbt_opts} \

--- a/sbt/sbt-launch-lib.bash
+++ b/sbt/sbt-launch-lib.bash
@@ -140,6 +140,16 @@ run() {
   set -- "${residual_args[@]}"
   argumentCount=$#
 
+
+  echo "$java_cmd" \
+    ${SBT_OPTS:-$default_sbt_opts} \
+    $(get_mem_opts $sbt_mem) \
+    ${java_opts} \
+    ${java_args[@]} \
+    -jar "$sbt_jar" \
+    "${sbt_commands[@]}" \
+    "${residual_args[@]}"
+
   # run sbt
   execRunner "$java_cmd" \
     ${SBT_OPTS:-$default_sbt_opts} \

--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -322,6 +322,7 @@ class SharkCliDriver(loadRdds: Boolean = false) extends CliDriver with LogHelper
           if (end > start) {
             val timeTaken:Double = (end - start) / 1000.0
             console.printInfo("Time taken: " + timeTaken + " seconds", null)
+            logInfo("Time taken: " + timeTaken + " seconds")
           }
 
           // Destroy the driver to release all the locks.

--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -322,7 +322,6 @@ class SharkCliDriver(loadRdds: Boolean = false) extends CliDriver with LogHelper
           if (end > start) {
             val timeTaken:Double = (end - start) / 1000.0
             console.printInfo("Time taken: " + timeTaken + " seconds", null)
-            logInfo("Time taken: " + timeTaken + " seconds")
           }
 
           // Destroy the driver to release all the locks.

--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -54,10 +54,8 @@ object SharkConfVars {
   val COMPRESS_QUERY_PLAN = new ConfVar("shark.compressQueryPlan", true)
 
   // Various compression schemes possible for storing data in memory
-  val COLUMNAR_COMPR_STRING = 
-    new ConfVar("shark.columnar.compr.string", "auto")
-  val COLUMNAR_COMPR_INT = 
-    new ConfVar("shark.columnar.compr.int", "auto")
+  val COLUMNAR_COMPR_STRING = new ConfVar("shark.columnar.compr.string", "auto")
+  val COLUMNAR_COMPR_INT = new ConfVar("shark.columnar.compr.int", "auto")
 
   // Add Shark configuration variables and their default values to the given conf,
   // so default values show up in 'set'.
@@ -74,10 +72,12 @@ object SharkConfVars {
       conf.setBoolean(COMPRESS_QUERY_PLAN.varname, COMPRESS_QUERY_PLAN.defaultBoolVal)
     if (conf.get(MAP_PRUNING.varname) == null)
       conf.setBoolean(MAP_PRUNING.varname, MAP_PRUNING.defaultBoolVal)
-    // if (conf.get(COLUMNAR_COMPR_INT.varname) == null)
-    //   conf.set(COLUMNAR_COMPR_INT.varname, COLUMNAR_COMPR_INT.defaultVal)
-    // if (conf.get(COLUMNAR_COMPR_STRING.varname) == null)
-    //   conf.set(COLUMNAR_COMPR_STRING.varname, COLUMNAR_COMPR_STRING.defaultVal)
+    if (conf.get(MAP_PRUNING_PRINT_DEBUG.varname) == null)
+      conf.setBoolean(MAP_PRUNING_PRINT_DEBUG.varname, MAP_PRUNING_PRINT_DEBUG.defaultBoolVal)
+    if (conf.get(COLUMNAR_COMPR_INT.varname) == null)
+      conf.set(COLUMNAR_COMPR_INT.varname, COLUMNAR_COMPR_INT.defaultVal)
+    if (conf.get(COLUMNAR_COMPR_STRING.varname) == null)
+      conf.set(COLUMNAR_COMPR_STRING.varname, COLUMNAR_COMPR_STRING.defaultVal)
   }
 
   def getIntVar(conf: Configuration, variable: ConfVar): Int = {

--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -53,6 +53,12 @@ object SharkConfVars {
   // If true, then query plans are compressed before being sent
   val COMPRESS_QUERY_PLAN = new ConfVar("shark.compressQueryPlan", true)
 
+  // Various compression schemes possible for storing data in memory
+  val COLUMNAR_COMPR_STRING = 
+    new ConfVar("shark.columnar.compr.string", "auto")
+  val COLUMNAR_COMPR_INT = 
+    new ConfVar("shark.columnar.compr.int", "auto")
+
   // Add Shark configuration variables and their default values to the given conf,
   // so default values show up in 'set'.
   def initializeWithDefaults(conf: Configuration) {
@@ -68,8 +74,10 @@ object SharkConfVars {
       conf.setBoolean(COMPRESS_QUERY_PLAN.varname, COMPRESS_QUERY_PLAN.defaultBoolVal)
     if (conf.get(MAP_PRUNING.varname) == null)
       conf.setBoolean(MAP_PRUNING.varname, MAP_PRUNING.defaultBoolVal)
-    if (conf.get(MAP_PRUNING_PRINT_DEBUG.varname) == null)
-      conf.setBoolean(MAP_PRUNING_PRINT_DEBUG.varname, MAP_PRUNING_PRINT_DEBUG.defaultBoolVal)
+    // if (conf.get(COLUMNAR_COMPR_INT.varname) == null)
+    //   conf.set(COLUMNAR_COMPR_INT.varname, COLUMNAR_COMPR_INT.defaultVal)
+    // if (conf.get(COLUMNAR_COMPR_STRING.varname) == null)
+    //   conf.set(COLUMNAR_COMPR_STRING.varname, COLUMNAR_COMPR_STRING.defaultVal)
   }
 
   def getIntVar(conf: Configuration, variable: ConfVar): Int = {

--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -54,8 +54,8 @@ object SharkConfVars {
   val COMPRESS_QUERY_PLAN = new ConfVar("shark.compressQueryPlan", true)
 
   // Various compression schemes possible for storing data in memory
-  val COLUMNAR_COMPR_STRING = new ConfVar("shark.columnar.compr.string", "auto")
-  val COLUMNAR_COMPR_INT = new ConfVar("shark.columnar.compr.int", "auto")
+  val COLUMN_COMPRESS_STRING = new ConfVar("shark.column.compress.string", "auto")
+  val COLUMN_COMPRESS_INT = new ConfVar("shark.column.compress.int", "auto")
 
   // Add Shark configuration variables and their default values to the given conf,
   // so default values show up in 'set'.
@@ -74,10 +74,10 @@ object SharkConfVars {
       conf.setBoolean(MAP_PRUNING.varname, MAP_PRUNING.defaultBoolVal)
     if (conf.get(MAP_PRUNING_PRINT_DEBUG.varname) == null)
       conf.setBoolean(MAP_PRUNING_PRINT_DEBUG.varname, MAP_PRUNING_PRINT_DEBUG.defaultBoolVal)
-    if (conf.get(COLUMNAR_COMPR_INT.varname) == null)
-      conf.set(COLUMNAR_COMPR_INT.varname, COLUMNAR_COMPR_INT.defaultVal)
-    if (conf.get(COLUMNAR_COMPR_STRING.varname) == null)
-      conf.set(COLUMNAR_COMPR_STRING.varname, COLUMNAR_COMPR_STRING.defaultVal)
+    if (conf.get(COLUMN_COMPRESS_INT.varname) == null)
+      conf.set(COLUMN_COMPRESS_INT.varname, COLUMN_COMPRESS_INT.defaultVal)
+    if (conf.get(COLUMN_COMPRESS_STRING.varname) == null)
+      conf.set(COLUMN_COMPRESS_STRING.varname, COLUMN_COMPRESS_STRING.defaultVal)
   }
 
   def getIntVar(conf: Configuration, variable: ConfVar): Int = {

--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -82,7 +82,6 @@ object SharkEnv extends LogHelper {
 
   System.setProperty("spark.serializer", classOf[spark.KryoSerializer].getName)
   System.setProperty("spark.kryo.registrator", classOf[KryoRegistrator].getName)
-  System.setProperty("spark.serializer", classOf[spark.KryoSerializer].getName)
 
   val executorEnvVars = new HashMap[String, String]
   executorEnvVars.put("SCALA_HOME", getEnv("SCALA_HOME"))

--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -36,7 +36,6 @@ object SharkEnv extends LogHelper {
           System.getenv("SPARK_HOME"),
           Nil,
           executorEnvVars)
-      sc.addSparkListener(new StatsReportListener())
     }
     sc
   }
@@ -53,7 +52,6 @@ object SharkEnv extends LogHelper {
         System.getenv("SPARK_HOME"),
         Nil,
         executorEnvVars)
-    sc.addSparkListener(new StatsReportListener())
     sc.asInstanceOf[SharkContext]
   }
 
@@ -82,6 +80,7 @@ object SharkEnv extends LogHelper {
 
   System.setProperty("spark.serializer", classOf[spark.KryoSerializer].getName)
   System.setProperty("spark.kryo.registrator", classOf[KryoRegistrator].getName)
+  System.setProperty("spark.serializer", classOf[spark.KryoSerializer].getName)
 
   val executorEnvVars = new HashMap[String, String]
   executorEnvVars.put("SCALA_HOME", getEnv("SCALA_HOME"))

--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -36,6 +36,7 @@ object SharkEnv extends LogHelper {
           System.getenv("SPARK_HOME"),
           Nil,
           executorEnvVars)
+      sc.addSparkListener(new StatsReportListener())
     }
     sc
   }
@@ -52,6 +53,7 @@ object SharkEnv extends LogHelper {
         System.getenv("SPARK_HOME"),
         Nil,
         executorEnvVars)
+    sc.addSparkListener(new StatsReportListener())
     sc.asInstanceOf[SharkContext]
   }
 

--- a/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
+++ b/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
@@ -76,13 +76,13 @@ class MemoryStoreSinkOperator extends TerminalOperator {
       }
 
     var tableProperties = op.localHiveOp.getConf.getTableInfo.getProperties()
-    if (createTableProperties.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname) != null) {
-      tableProperties.setProperty(SharkConfVars.COLUMNAR_COMPR_STRING.varname,
-        createTableProperties.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname).toString)
+    if (createTableProperties.get(SharkConfVars.COLUMN_COMPRESS_STRING.varname) != null) {
+      tableProperties.setProperty(SharkConfVars.COLUMN_COMPRESS_STRING.varname,
+        createTableProperties.get(SharkConfVars.COLUMN_COMPRESS_STRING.varname).toString)
     }
-    if (createTableProperties.get(SharkConfVars.COLUMNAR_COMPR_INT.varname) != null) {
-      tableProperties.setProperty(SharkConfVars.COLUMNAR_COMPR_INT.varname,
-        createTableProperties.get(SharkConfVars.COLUMNAR_COMPR_INT.varname).toString)
+    if (createTableProperties.get(SharkConfVars.COLUMN_COMPRESS_INT.varname) != null) {
+      tableProperties.setProperty(SharkConfVars.COLUMN_COMPRESS_INT.varname,
+        createTableProperties.get(SharkConfVars.COLUMN_COMPRESS_INT.varname).toString)
     }
     op.logInfo("Op Table Properties - " + tableProperties)
 

--- a/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
+++ b/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
@@ -25,15 +25,14 @@ import scala.reflect.BeanProperty
 
 import org.apache.hadoop.io.Writable
 
-import shark.{SharkConfVars, SharkEnv, SharkEnvSlave, Utils}
-import shark.execution.serialization.{OperatorSerializationWrapper, JavaSerializer}
+import shark.{ SharkConfVars, SharkEnv, SharkEnvSlave, Utils }
+import shark.execution.serialization.{ OperatorSerializationWrapper, JavaSerializer }
 import shark.memstore2._
 import shark.tachyon.TachyonTableWriter
 
-import spark.{RDD, TaskContext}
+import spark.{ RDD, TaskContext }
 import spark.SparkContext._
 import spark.storage.StorageLevel
-
 
 /**
  * Cache the RDD and force evaluate it (so the cache is filled).
@@ -64,8 +63,8 @@ class MemoryStoreSinkOperator extends TerminalOperator {
     val op = OperatorSerializationWrapper(this)
 
     val tableName = createTableProperties.getProperty("name")
-    if(tableName == null) {
-      throw new RuntimeException(" " + createTableProperties)
+    if (tableName == null) {
+      throw new RuntimeException("Table name is NULL - table properties - " + createTableProperties)
     }
 
     val tachyonWriter: TachyonTableWriter =
@@ -87,29 +86,29 @@ class MemoryStoreSinkOperator extends TerminalOperator {
     }
     op.logInfo("Op Table Properties - " + tableProperties)
 
-
     // Put all rows of the table into a set of TablePartition's. Each partition contains
     // only one TablePartition object.
-    var rdd: RDD[TablePartition] = inputRdd.mapPartitionsWithIndex { case(partitionIndex, iter) =>
-      op.initializeOnSlave()
-      val serde = new ColumnarSerDe
-      serde.initialize(op.hconf, tableProperties)
+    var rdd: RDD[TablePartition] = inputRdd.mapPartitionsWithIndex {
+      case (partitionIndex, iter) =>
+        op.initializeOnSlave()
+        val serde = new ColumnarSerDe
+        serde.initialize(op.hconf, tableProperties)
 
-      // Serialize each row into the builder object.
-      // ColumnarSerDe will return a TablePartitionBuilder.
-      var builder: Writable = null
-      iter.foreach { row =>
-        builder = serde.serialize(row.asInstanceOf[AnyRef], op.objectInspector)
-      }
+        // Serialize each row into the builder object.
+        // ColumnarSerDe will return a TablePartitionBuilder.
+        var builder: Writable = null
+        iter.foreach { row =>
+          builder = serde.serialize(row.asInstanceOf[AnyRef], op.objectInspector)
+        }
 
-      if (builder != null) {
-        statsAcc += Tuple2(partitionIndex, builder.asInstanceOf[TablePartitionBuilder].stats)
-        Iterator(builder.asInstanceOf[TablePartitionBuilder].build)
-      } else {
-        // Empty partition.
-        statsAcc += Tuple2(partitionIndex, new TablePartitionStats(Array(), 0))
-        Iterator(new TablePartition(0, Array()))
-      }
+        if (builder != null) {
+          statsAcc += Tuple2(partitionIndex, builder.asInstanceOf[TablePartitionBuilder].stats)
+          Iterator(builder.asInstanceOf[TablePartitionBuilder].build)
+        } else {
+          // Empty partition.
+          statsAcc += Tuple2(partitionIndex, new TablePartitionStats(Array(), 0))
+          Iterator(new TablePartition(0, Array()))
+        }
     }
 
     if (tachyonWriter != null) {
@@ -119,12 +118,14 @@ class MemoryStoreSinkOperator extends TerminalOperator {
       SharkEnv.memoryMetadataManager.put(tableName, rdd)
 
       tachyonWriter.createTable(ByteBuffer.allocate(0))
-      rdd = rdd.mapPartitionsWithIndex { case(partitionIndex, iter) =>
-        val partition = iter.next()
-        partition.toTachyon.zipWithIndex.foreach { case(buf, column) =>
-          tachyonWriter.writeColumnPartition(column, partitionIndex, buf)
-        }
-        Iterator(partition)
+      rdd = rdd.mapPartitionsWithIndex {
+        case (partitionIndex, iter) =>
+          val partition = iter.next()
+          partition.toTachyon.zipWithIndex.foreach {
+            case (buf, column) =>
+              tachyonWriter.writeColumnPartition(column, partitionIndex, buf)
+          }
+          Iterator(partition)
       }
       // Force evaluate so the data gets put into Tachyon.
       rdd.foreach(_ => Unit)
@@ -185,8 +186,9 @@ class MemoryStoreSinkOperator extends TerminalOperator {
     }
 
     if (SharkConfVars.getBoolVar(localHconf, SharkConfVars.MAP_PRUNING_PRINT_DEBUG)) {
-      columnStats.foreach { case(index, tableStats) =>
-        println("Partition " + index + " " + tableStats.toString)
+      columnStats.foreach {
+        case (index, tableStats) =>
+          println("Partition " + index + " " + tableStats.toString)
       }
     }
 

--- a/src/main/scala/shark/execution/OperatorFactory.scala
+++ b/src/main/scala/shark/execution/OperatorFactory.scala
@@ -17,6 +17,7 @@
 
 package shark.execution
 
+import java.util.Properties
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.hive.ql.exec.{GroupByPostShuffleOperator, GroupByPreShuffleOperator}
@@ -44,14 +45,14 @@ object OperatorFactory extends LogHelper {
 
   def createSharkMemoryStoreOutputPlan(
       hiveTerminalOp: HiveOperator,
-      tableName: String,
+      tableProperties: Properties,
       storageLevel: StorageLevel,
       numColumns: Int,
       useTachyon: Boolean,
       useUnionRDD: Boolean): TerminalOperator = {
     val sinkOp = _newOperatorInstance(
       classOf[MemoryStoreSinkOperator], hiveTerminalOp).asInstanceOf[MemoryStoreSinkOperator]
-    sinkOp.tableName = tableName
+    sinkOp.createTableProperties.putAll(tableProperties)
     sinkOp.storageLevel = storageLevel
     sinkOp.numColumns = numColumns
     sinkOp.useTachyon = useTachyon

--- a/src/main/scala/shark/memstore2/ColumnarSerDe.scala
+++ b/src/main/scala/shark/memstore2/ColumnarSerDe.scala
@@ -54,16 +54,16 @@ class ColumnarSerDe extends SerDe with LogHelper {
     objectInspector = ColumnarStructObjectInspector(serDeParams)
 
     if(tbl != null) {
-      if(tbl.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname) != null) {
-        columnarComprString = tbl.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname).toString
+      if(tbl.get(SharkConfVars.COLUMN_COMPRESS_STRING.varname) != null) {
+        columnarComprString = tbl.get(SharkConfVars.COLUMN_COMPRESS_STRING.varname).toString
       } else {
-        columnarComprString = SharkConfVars.COLUMNAR_COMPR_STRING.defaultVal
+        columnarComprString = SharkConfVars.COLUMN_COMPRESS_STRING.defaultVal
       }
 
-      if (tbl.get(SharkConfVars.COLUMNAR_COMPR_INT.varname) != null) {
-        columnarComprInt = tbl.get(SharkConfVars.COLUMNAR_COMPR_INT.varname).toString
+      if (tbl.get(SharkConfVars.COLUMN_COMPRESS_INT.varname) != null) {
+        columnarComprInt = tbl.get(SharkConfVars.COLUMN_COMPRESS_INT.varname).toString
       } else {
-        columnarComprInt = SharkConfVars.COLUMNAR_COMPR_INT.defaultVal
+        columnarComprInt = SharkConfVars.COLUMN_COMPRESS_INT.defaultVal
       }
 
       logDebug("columnarComprString configured as  " + columnarComprString)

--- a/src/main/scala/shark/memstore2/ColumnarSerDe.scala
+++ b/src/main/scala/shark/memstore2/ColumnarSerDe.scala
@@ -56,10 +56,14 @@ class ColumnarSerDe extends SerDe with LogHelper {
     if(tbl != null) {
       if(tbl.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname) != null) {
         columnarComprString = tbl.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname).toString
+      } else {
+        columnarComprString = SharkConfVars.COLUMNAR_COMPR_STRING.defaultVal
       }
 
       if (tbl.get(SharkConfVars.COLUMNAR_COMPR_INT.varname) != null) {
         columnarComprInt = tbl.get(SharkConfVars.COLUMNAR_COMPR_INT.varname).toString
+      } else {
+        columnarComprInt = SharkConfVars.COLUMNAR_COMPR_INT.defaultVal
       }
 
       logDebug("columnarComprString configured as  " + columnarComprString)

--- a/src/main/scala/shark/memstore2/ColumnarSerDe.scala
+++ b/src/main/scala/shark/memstore2/ColumnarSerDe.scala
@@ -55,13 +55,11 @@ class ColumnarSerDe extends SerDe with LogHelper {
 
     if(tbl != null) {
       if(tbl.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname) != null) {
-        columnarComprString =
-          tbl.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname).toString
+        columnarComprString = tbl.get(SharkConfVars.COLUMNAR_COMPR_STRING.varname).toString
       }
 
       if (tbl.get(SharkConfVars.COLUMNAR_COMPR_INT.varname) != null) {
-        columnarComprInt =
-          tbl.get(SharkConfVars.COLUMNAR_COMPR_INT.varname).toString
+        columnarComprInt = tbl.get(SharkConfVars.COLUMNAR_COMPR_INT.varname).toString
       }
 
       logDebug("columnarComprString configured as  " + columnarComprString)
@@ -72,8 +70,7 @@ class ColumnarSerDe extends SerDe with LogHelper {
     // an instance of the table's StructObjectInspector by creating an instance SerDe, which
     // it initializes by passing a 'null' argument for 'conf'.
     if (conf != null) {
-      initialColumnSize = SharkConfVars.getIntVar(conf,
-        SharkConfVars.COLUMN_INITIALSIZE)
+      initialColumnSize = SharkConfVars.getIntVar(conf, SharkConfVars.COLUMN_INITIALSIZE)
 
       if (initialColumnSize == - 1) {
         // Approximate the size of a partition by using the HDFS "dfs.block.size" config.

--- a/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
+++ b/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
@@ -40,12 +40,18 @@ class TablePartitionBuilder(oi: StructObjectInspector, initialColumnSize: Int,
   val columnBuilders = Array.tabulate[ColumnBuilder[_]](fields.size) { i =>
     val columnBuilder = ColumnBuilder.create(fields.get(i).getFieldObjectInspector)
 
-    columnBuilder match {
-      case _: StringColumnBuilder => 
-        columnBuilder.scheme = CompressionScheme.withName(columnarComprString.capitalize)
-      case _: IntColumnBuilder    => 
-        columnBuilder.scheme = CompressionScheme.withName(columnarComprInt.capitalize)
-      case _ => // Do nothing - "Column type does not support compression - TablePartitionBuilder"
+    try {
+      columnBuilder match {
+        case _: StringColumnBuilder =>
+          columnBuilder.scheme = CompressionScheme.withName(columnarComprString.toLowerCase.capitalize)
+        case _: IntColumnBuilder    =>
+          columnBuilder.scheme = CompressionScheme.withName(columnarComprInt.toLowerCase.capitalize)
+        case _ => // Do nothing - "Column type does not support compression - TablePartitionBuilder"
+      }
+    } catch {
+      case ex: NoSuchElementException => throw new
+          NoSuchElementException("Bad compression scheme requested - int [" + columnarComprInt + 
+            "] - string [" + columnarComprString + "]");
     }
 
     columnBuilder.initialize(initialColumnSize)

--- a/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
+++ b/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
@@ -41,8 +41,8 @@ class TablePartitionBuilder(oi: StructObjectInspector, initialColumnSize: Int,
     val columnBuilder = ColumnBuilder.create(fields.get(i).getFieldObjectInspector)
 
     columnBuilder match {
-      case _:StringColumnBuilder => columnBuilder.scheme = columnarComprString
-      case _:IntColumnBuilder    => columnBuilder.scheme = columnarComprInt
+      case _: StringColumnBuilder => columnBuilder.scheme = columnarComprString
+      case _: IntColumnBuilder    => columnBuilder.scheme = columnarComprInt
       case _ => // Do nothing - "Column type does not support compression - TablePartitionBuilder"
     }
 

--- a/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
+++ b/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
@@ -41,8 +41,10 @@ class TablePartitionBuilder(oi: StructObjectInspector, initialColumnSize: Int,
     val columnBuilder = ColumnBuilder.create(fields.get(i).getFieldObjectInspector)
 
     columnBuilder match {
-      case _: StringColumnBuilder => columnBuilder.scheme = columnarComprString
-      case _: IntColumnBuilder    => columnBuilder.scheme = columnarComprInt
+      case _: StringColumnBuilder => 
+        columnBuilder.scheme = CompressionScheme.withName(columnarComprString.capitalize)
+      case _: IntColumnBuilder    => 
+        columnBuilder.scheme = CompressionScheme.withName(columnarComprInt.capitalize)
       case _ => // Do nothing - "Column type does not support compression - TablePartitionBuilder"
     }
 

--- a/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
+++ b/src/main/scala/shark/memstore2/TablePartitionBuilder.scala
@@ -35,7 +35,8 @@ import shark.memstore2.column.ColumnBuilder
  * Used to build a TablePartition. This is used in the serializer to convert a
  * partition of data into columnar format and to generate a TablePartition.
  */
-class TablePartitionBuilder(oi: StructObjectInspector, initialColumnSize: Int)
+class TablePartitionBuilder(oi: StructObjectInspector, initialColumnSize: Int,
+                            columnarComprString: String, columnarComprInt: String)
   extends Writable {
 
   var numRows: Long = 0
@@ -43,6 +44,8 @@ class TablePartitionBuilder(oi: StructObjectInspector, initialColumnSize: Int)
 
   val columnBuilders = Array.tabulate[ColumnBuilder[_]](fields.size) { i =>
     val columnBuilder = ColumnBuilder.create(fields.get(i).getFieldObjectInspector)
+    // columnBuilder.initialize(initialColumnSize, columnarComprString,
+    //columnarComprInt)
     columnBuilder.initialize(initialColumnSize)
     columnBuilder
   }

--- a/src/main/scala/shark/memstore2/TablePartitionIterator.scala
+++ b/src/main/scala/shark/memstore2/TablePartitionIterator.scala
@@ -49,7 +49,7 @@ class TablePartitionIterator(
     _position += 1
     var i = 0
     while (i < _columnIteratorsToAdvance.size) {
-      _columnIteratorsToAdvance(i).next
+      _columnIteratorsToAdvance(i).next()
       i += 1
     }
     _struct

--- a/src/main/scala/shark/memstore2/buffer/ByteBufferReader.scala
+++ b/src/main/scala/shark/memstore2/buffer/ByteBufferReader.scala
@@ -50,6 +50,8 @@ trait ByteBufferReader {
 
   def position: Int
 
+  def duplicate(): ByteBufferReader
+
   def printDebug()
 }
 

--- a/src/main/scala/shark/memstore2/buffer/JavaByteBufferReader.scala
+++ b/src/main/scala/shark/memstore2/buffer/JavaByteBufferReader.scala
@@ -90,6 +90,11 @@ class JavaByteBufferReader(buf: ByteBuffer) extends ByteBufferReader {
 
   override def position: Int = _buf.position()
 
+  override def duplicate(): ByteBufferReader = {
+    // JavaByteBufferReader in its constructor will make a duplicate of the buffer.
+    new JavaByteBufferReader(_buf)
+  }
+
   override def printDebug() {
     val b = _buf.duplicate()
     while (b.hasRemaining()) print(b.get() + " ")

--- a/src/main/scala/shark/memstore2/buffer/UnsafeDirectByteBufferReader.scala
+++ b/src/main/scala/shark/memstore2/buffer/UnsafeDirectByteBufferReader.scala
@@ -101,6 +101,12 @@ class UnsafeDirectByteBufferReader(buf: java.nio.ByteBuffer) extends ByteBufferR
 
   override def position: Int = (_offset - _base_offset).toInt
 
+  override def duplicate(): ByteBufferReader = {
+    val dup = new UnsafeDirectByteBufferReader(buf)
+    dup._offset = this._offset
+    dup
+  }
+
   private def getMemoryAddress(buffer: java.nio.ByteBuffer): Long = {
     val addressField = classOf[java.nio.Buffer].getDeclaredField("address")
     addressField.setAccessible(true)

--- a/src/main/scala/shark/memstore2/buffer/UnsafeHeapByteBufferReader.scala
+++ b/src/main/scala/shark/memstore2/buffer/UnsafeHeapByteBufferReader.scala
@@ -30,9 +30,9 @@ class UnsafeHeapByteBufferReader(buf: ByteBuffer) extends ByteBufferReader {
     throw new IllegalArgumentException("buf (" + buf + ") must have a backing array. ")
   }
 
+  private val _arr: Array[Byte] = buf.array()
   private val _base_offset: Long = Unsafe.BYTE_ARRAY_BASE_OFFSET
   private var _offset: Long = _base_offset
-  private var _arr: Array[Byte] = buf.array()
 
   override def getByte(): Byte = {
     val v = Unsafe.unsafe.getByte(_arr, _offset)
@@ -105,6 +105,12 @@ class UnsafeHeapByteBufferReader(buf: ByteBuffer) extends ByteBufferReader {
   }
 
   override def position: Int = (_offset - _base_offset).toInt
+
+  override def duplicate(): ByteBufferReader = {
+    val dup = new UnsafeHeapByteBufferReader(buf)
+    dup._offset = this._offset
+    dup
+  }
 
   override def printDebug() {
     var i = 0

--- a/src/main/scala/shark/memstore2/column/BooleanColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/BooleanColumnBuilder.scala
@@ -29,10 +29,10 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInsp
 class BooleanColumnBuilder extends ColumnBuilder[Boolean] {
 
   private var _stats: ColumnStats.BooleanColumnStats = null
-  private var _arr: BooleanArrayList = null
+  private var _nonNulls: BooleanArrayList = null
 
   override def initialize(initialSize: Int) {
-    _arr = new BooleanArrayList(initialSize)
+    _nonNulls = new BooleanArrayList(initialSize)
     _stats = new ColumnStats.BooleanColumnStats
     super.initialize(initialSize)
   }
@@ -47,28 +47,27 @@ class BooleanColumnBuilder extends ColumnBuilder[Boolean] {
   }
 
   override def append(v: Boolean) {
-    _arr.add(v)
+    _nonNulls.add(v)
     _stats.append(v)
   }
 
   override def appendNull() {
-    _nullBitmap.set(_arr.size)
-    _arr.add(false)
+    _nullBitmap.set(_nonNulls.size + _stats.nullCount)
     _stats.appendNull()
   }
 
   override def stats = _stats
 
   override def build: ByteBuffer = {
-    val buf = ByteBuffer.allocate(_arr.size + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
+    val buf = ByteBuffer.allocate(_nonNulls.size + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
     buf.order(ByteOrder.nativeOrder())
     buf.putLong(ColumnIterator.BOOLEAN)
 
     writeNullBitmap(buf)
 
     var i = 0
-    while (i < _arr.size) {
-      buf.put(if (_arr.get(i)) 1.toByte else 0.toByte)
+    while (i < _nonNulls.size) {
+      buf.put(if (_nonNulls.get(i)) 1.toByte else 0.toByte)
       i += 1
     }
     buf.rewind()

--- a/src/main/scala/shark/memstore2/column/ByteColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ByteColumnBuilder.scala
@@ -29,11 +29,11 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspect
 class ByteColumnBuilder extends ColumnBuilder[Byte] {
 
   private var _stats: ColumnStats.ByteColumnStats = null
-  private var _arr: ByteArrayList = null
+  private var _nonNulls: ByteArrayList = null
   private val zero: Byte = 0
 
   override def initialize(initialSize: Int) {
-    _arr = new ByteArrayList(initialSize)
+    _nonNulls = new ByteArrayList(initialSize)
     _stats = new ColumnStats.ByteColumnStats
     super.initialize(initialSize)
   }
@@ -48,28 +48,27 @@ class ByteColumnBuilder extends ColumnBuilder[Byte] {
   }
 
   override def append(v: Byte) {
-    _arr.add(v)
+    _nonNulls.add(v)
     _stats.append(v)
   }
 
   override def appendNull() {
-    _nullBitmap.set(_arr.size)
-    _arr.add(zero)
+    _nullBitmap.set(_nonNulls.size + _stats.nullCount)
     _stats.appendNull()
   }
 
   override def stats = _stats
 
   override def build: ByteBuffer = {
-    val buf = ByteBuffer.allocate(_arr.size + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
+    val buf = ByteBuffer.allocate(_nonNulls.size + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
     buf.order(ByteOrder.nativeOrder())
     buf.putLong(ColumnIterator.BYTE)
 
     writeNullBitmap(buf)
 
     var i = 0
-    while (i < _arr.size) {
-      buf.put(_arr.get(i))
+    while (i < _nonNulls.size) {
+      buf.put(_nonNulls.get(i))
       i += 1
     }
     buf.rewind()

--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory
 
+import shark.memstore2.column.CompressionScheme._
 
 /** Builder interface for a column. Each column type (PrimitiveCategory) would
  * be expected to implement its own builder. Each builder takes an array of
@@ -73,7 +74,7 @@ trait ColumnBuilder[@specialized(Boolean, Byte, Short, Int, Long, Float, Double)
   /** Compression/Encoding scheme for the column. Not supported by all types
     * Setter should be called before build()
     */
-  var scheme: String = "auto"
+  var scheme = CompressionScheme.Auto
 
   protected var _nullBitmap: EWAHCompressedBitmap = null
 
@@ -88,7 +89,6 @@ trait ColumnBuilder[@specialized(Boolean, Byte, Short, Int, Long, Float, Double)
     }
   }
 }
-
 
 object ColumnBuilder {
 

--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -64,25 +64,16 @@ trait ColumnBuilder[@specialized(Boolean, Byte, Short, Int, Long, Float, Double)
 
   def build: ByteBuffer
 
-  private def initializeImpl() {
-    _nullBitmap = new EWAHCompressedBitmap
-  }
-
   /** Subclasses should call super.initialize to initialize the null bitmap. 
     */
   def initialize(initialSize: Int) {
-    initializeImpl
+    _nullBitmap = new EWAHCompressedBitmap
   }
 
-  /** Subclasses should call super.initialize to initialize the null bitmap. 
-    * Uses this method because Scala does not allow mixing overridden functions
-    * and default values easily
+  /** Compression/Encoding scheme for the column. Not supported by all types
+    * Setter should be called before build()
     */
-  def initialize(initialSize: Int,
-                 columnarComprString: String,
-                 columnarComprInt: String) {
-    initializeImpl
-  }
+  var scheme: String = "auto"
 
   protected var _nullBitmap: EWAHCompressedBitmap = null
 

--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -39,9 +39,21 @@ trait ColumnBuilder[@specialized(Boolean, Byte, Short, Int, Long, Float, Double)
 
   def build: ByteBuffer
 
+  private def initializeImpl() {
+    _nullBitmap = new EWAHCompressedBitmap
+  }
+
   // Subclasses should call super.initialize to initialize the null bitmap.
   def initialize(initialSize: Int) {
-    _nullBitmap = new EWAHCompressedBitmap
+    initializeImpl
+  }
+
+  // scala does not allow mixing overridden functions and default values easily
+  // Subclasses should call super.initialize to initialize the null bitmap.
+  def initialize(initialSize: Int,
+                 columnarComprString: String,
+                 columnarComprInt: String) {
+    initializeImpl
   }
 
   protected var _nullBitmap: EWAHCompressedBitmap = null

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -18,7 +18,7 @@
 package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
-
+import shark.LogHelper
 
 /**
  * Iterator interface for a column. The iterator should be initialized by a byte
@@ -28,6 +28,8 @@ abstract class ColumnIterator {
 
   def next()
 
+  // Should be implemented as a read-only operation by the ColumnIterator
+  // Can be called any number of times
   def current: Object
 }
 
@@ -35,7 +37,7 @@ abstract class ColumnIterator {
 /**
  * A mapping from an integer column type to the respective ColumnIterator class.
  */
-object ColumnIterator {
+object ColumnIterator extends LogHelper {
 
   // TODO: Implement Decimal data type.
 

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -18,7 +18,6 @@
 package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
-import shark.LogHelper
 
 /** Iterator interface for a column. The iterator should be initialized by a
  * byte buffer, and next can be invoked to get the value for each cell.
@@ -133,13 +132,15 @@ object ColumnIterator {
   _iteratorFactory(BINARY) = createFactory(classOf[BinaryColumnIterator.Default])
 
   val DICT_INT = 13
-  _iteratorFactory(DICT_INT) = createFactoryWithEWAH(classOf[DictionaryEncodedIntColumnIterator.Default])
+  _iteratorFactory(DICT_INT) =
+    createFactoryWithEWAH(classOf[DictionaryEncodedIntColumnIterator.Default])
 
   val RLE_STRING = 14
   _iteratorFactory(RLE_STRING) = createFactoryWithRLE(classOf[StringColumnIterator.Default])
 
-  // val DICT_STRING = 15
-  // _iteratorFactory(DICT_STRING) = createFactory(classOf[DictionaryEncodedStringColumnIterator.Default])
+  val DICT_STRING = 15
+  // _iteratorFactory(DICT_STRING) =
+  //   createFactory(classOf[DictionaryEncodedStringColumnIterator.Default])
 
   val LZF_STRING = 16
   _iteratorFactory(LZF_STRING) = createFactoryWithLZF(classOf[StringColumnIterator.Default])

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -123,6 +123,9 @@ object ColumnIterator extends LogHelper {
   val LZF_STRING = 16
   _iteratorFactory(LZF_STRING) = createFactoryWithLZF(classOf[StringColumnIterator.Default])
 
+  val RLE_INT = 17
+  _iteratorFactory(RLE_INT) = ColumnIteratorFactory.createIntWithEwahRLE
+
   // Helper methods so we don't need to write the whole thing up there.
   def createFactory[T <: ColumnIterator](c: Class[T]) = {
     ColumnIteratorFactory.create(c)

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -114,6 +114,15 @@ object ColumnIterator extends LogHelper {
   val DICT_INT = 13
   _iteratorFactory(DICT_INT) = createFactoryWithEWAH(classOf[DictionaryEncodedIntColumnIterator.Default])
 
+  val RLE_STRING = 14
+  _iteratorFactory(RLE_STRING) = createFactoryWithRLE(classOf[StringColumnIterator.Default])
+
+  // val DICT_STRING = 15
+  // _iteratorFactory(DICT_STRING) = createFactory(classOf[DictionaryEncodedStringColumnIterator.Default])
+
+  val LZF_STRING = 16
+  _iteratorFactory(LZF_STRING) = createFactoryWithLZF(classOf[StringColumnIterator.Default])
+
   // Helper methods so we don't need to write the whole thing up there.
   def createFactory[T <: ColumnIterator](c: Class[T]) = {
     ColumnIteratorFactory.create(c)
@@ -123,4 +132,11 @@ object ColumnIterator extends LogHelper {
     ColumnIteratorFactory.createWithEWAH(c)
   }
 
+  def createFactoryWithRLE[T <: ColumnIterator](c: Class[T]) = {
+    ColumnIteratorFactory.createWithRLE(c)
+  }
+
+  def createFactoryWithLZF[T <: ColumnIterator](c: Class[T]) = {
+    ColumnIteratorFactory.createWithLZF(c)
+  }
 }

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -18,13 +18,16 @@
 package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
-import shark.LogHelper
 
 /**
  * Iterator interface for a column. The iterator should be initialized by a byte
  * buffer, and next can be invoked to get the value for each cell.
  */
 abstract class ColumnIterator {
+
+  // logger problems - rmeove before commit
+  private def logInfo(msg: String) = { println("INFO " + msg) }
+  private def logDebug(msg: String) = { println("DEBUG " + msg) }
 
   def next()
 
@@ -37,7 +40,7 @@ abstract class ColumnIterator {
 /**
  * A mapping from an integer column type to the respective ColumnIterator class.
  */
-object ColumnIterator extends LogHelper {
+object ColumnIterator {
 
   // TODO: Implement Decimal data type.
 

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -18,6 +18,7 @@
 package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
+import shark.LogHelper
 
 /** Iterator interface for a column. The iterator should be initialized by a
  * byte buffer, and next can be invoked to get the value for each cell.
@@ -45,10 +46,6 @@ import shark.memstore2.buffer.ByteBufferReader
  * 
  */
 abstract class ColumnIterator {
-
-  // logger problems - rmeove before commit
-  private def logInfo(msg: String) = { println("INFO " + msg) }
-  private def logDebug(msg: String) = { println("DEBUG " + msg) }
 
   def next()
 

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -148,6 +148,9 @@ object ColumnIterator {
   val RLE_INT = 17
   _iteratorFactory(RLE_INT) = ColumnIteratorFactory.createIntWithEwahRLE
 
+  val LZF_INT = 18
+  _iteratorFactory(LZF_INT) = ColumnIteratorFactory.createIntWithEwahLZF
+
   // Helper methods so we don't need to write the whole thing up there.
   def createFactory[T <: ColumnIterator](c: Class[T]) = {
     ColumnIteratorFactory.create(c)

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -19,9 +19,30 @@ package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
 
-/**
- * Iterator interface for a column. The iterator should be initialized by a byte
- * buffer, and next can be invoked to get the value for each cell.
+/** Iterator interface for a column. The iterator should be initialized by a
+ * byte buffer, and next can be invoked to get the value for each cell.
+ *
+ * Adding a new compression/encoding scheme to the code requires several
+ * things. First among them is an addition to the list of iterators here. An
+ * iterator that knows how to iterate through an encoding-specific ByteBuffer is
+ * required. This ByteBuffer would have been created by the one of the concrete
+ * [[shark.memstore2.buffer.ColumnBuilder]] classes.  
+ * 
+ * 
+ * The relationship/composition possibilities between the new
+ * encoding/compression and existing schemes dictates how the new iterator is
+ * implemented.  Null Encoding and RLE Encoding working as generic wrappers that
+ * can be wrapped around any data type.  Dictionary Encoding does not work in a
+ * hierarchial manner instead requiring the creation of a separate
+ * DictionaryEncoded Iterator per Data type.
+ * 
+ * The changes required for the LZF encoding's Builder/Iterator might be the
+ * easiest to look to get a feel for what is required -
+ * [[shark.memstore2.buffer.LZFColumnIterator]]. See SHA 225f4d90d8721a9d9e8f
+ * 
+ * The base class ColumnIterator is the read side of this equation. For the
+ * write side see [[shark.memstore2.buffer.ColumnBuilder]].
+ * 
  */
 abstract class ColumnIterator {
 

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -109,6 +109,9 @@ object ColumnIterator {
   val BINARY = 12
   _iteratorFactory(BINARY) = createFactory(classOf[BinaryColumnIterator.Default])
 
+  val DICT_INT = 13
+  _iteratorFactory(DICT_INT) = createFactoryWithEWAH(classOf[DictionaryEncodedIntColumnIterator.Default])
+
   // Helper methods so we don't need to write the whole thing up there.
   def createFactory[T <: ColumnIterator](c: Class[T]) = {
     ColumnIteratorFactory.create(c)

--- a/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
@@ -18,6 +18,7 @@
 package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
+import shark.LogHelper
 
 /**
  * Factory class used to create column iterators for a given data type.
@@ -25,16 +26,12 @@ import shark.memstore2.buffer.ByteBufferReader
  * of the column iterator to create depending on metadata embedded in the
  * buffer. For example, it can choose whether to handle null values or not.
  */
-trait ColumnIteratorFactory {
+trait ColumnIteratorFactory extends LogHelper{
   def createIterator(buf: ByteBufferReader): ColumnIterator
 }
 
 
 object ColumnIteratorFactory{
-
-  // logger problems - rmeove before commit
-  private def logInfo(msg: String) = { println("INFO " + msg) }
-  private def logDebug(msg: String) = { println("DEBUG " + msg) }
 
   /**
    * Create a factory for the given column iterator.

--- a/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
@@ -18,7 +18,7 @@
 package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
-
+import shark.LogHelper
 
 /**
  * Factory class used to create column iterators for a given data type.
@@ -31,7 +31,7 @@ trait ColumnIteratorFactory {
 }
 
 
-object ColumnIteratorFactory {
+object ColumnIteratorFactory extends LogHelper{
 
   /**
    * Create a factory for the given column iterator.
@@ -53,6 +53,7 @@ object ColumnIteratorFactory {
       override def createIterator(buf: ByteBufferReader): ColumnIterator = {
         val nullable = buf.getLong() == 1L
         if (nullable) {
+          logDebug("baseIterClass " + baseIterClass + " created with EWAH")
           new EWAHNullableColumnIterator[T](baseIterClass, buf)
         } else {
           val ctor = baseIterClass.getConstructor(classOf[ByteBufferReader])

--- a/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
@@ -62,4 +62,48 @@ object ColumnIteratorFactory extends LogHelper{
       }
     }
   }
+
+
+  /**
+   * Create a factory for a column iterator wrapped by Run Length encoding 
+   */
+  def createWithRLE[T <: ColumnIterator](baseIterClass: Class[T]): ColumnIteratorFactory = {
+    new ColumnIteratorFactory {
+      override def createIterator(buf: ByteBufferReader): ColumnIterator = {
+          logDebug("baseIterClass " + baseIterClass + " created with RLE")
+          new RLEColumnIterator[T](baseIterClass, buf)
+      }
+    }
+  }
+
+
+  /**
+   * Create a factory for a column iterator wrapped by LZF compression
+   */
+  def createWithLZF[T <: ColumnIterator](baseIterClass: Class[T]): ColumnIteratorFactory = {
+    new ColumnIteratorFactory {
+      override def createIterator(buf: ByteBufferReader): ColumnIterator = {
+          logInfo("baseIterClass " + baseIterClass + " created with LZF")
+          new LZFColumnIterator[T](baseIterClass, buf)
+      }
+    }
+  }
+ 
+/*
+  def createWithEWAHDecorator(c: ColumnIterator) = {
+    new ColumnIteratorFactory {
+      override def createIterator(buf: ByteBufferReader): ColumnIterator = {
+        val nullable = buf.getLong() == 1L
+        if (nullable) {
+          logDebug(
+            " created with EWAHDecorator")
+// troubles mixing mixins and reflection in scala
+          new (classOf[c].getInstance(buf) with EWAHNullableColumnIteratorDecorator)
+        } else {
+          c
+        }
+      }
+    }
+  }
+*/
 }

--- a/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
@@ -26,12 +26,12 @@ import shark.LogHelper
  * of the column iterator to create depending on metadata embedded in the
  * buffer. For example, it can choose whether to handle null values or not.
  */
-trait ColumnIteratorFactory extends LogHelper{
+trait ColumnIteratorFactory extends LogHelper {
   def createIterator(buf: ByteBufferReader): ColumnIterator
 }
 
 
-object ColumnIteratorFactory{
+object ColumnIteratorFactory {
 
   /**
    * Create a factory for the given column iterator.
@@ -111,21 +111,4 @@ object ColumnIteratorFactory{
     }
   }
  
-/*
-  def createWithEWAHDecorator(c: ColumnIterator) = {
-    new ColumnIteratorFactory {
-      override def createIterator(buf: ByteBufferReader): ColumnIterator = {
-        val nullable = buf.getLong() == 1L
-        if (nullable) {
-          logDebug(
-            " created with EWAHDecorator")
-// troubles mixing mixins and reflection in scala
-          new (classOf[c].getInstance(buf) with EWAHNullableColumnIteratorDecorator)
-        } else {
-          c
-        }
-      }
-    }
-  }
-*/
 }

--- a/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIteratorFactory.scala
@@ -18,7 +18,6 @@
 package shark.memstore2.column
 
 import shark.memstore2.buffer.ByteBufferReader
-import shark.LogHelper
 
 /**
  * Factory class used to create column iterators for a given data type.
@@ -31,7 +30,11 @@ trait ColumnIteratorFactory {
 }
 
 
-object ColumnIteratorFactory extends LogHelper{
+object ColumnIteratorFactory{
+
+  // logger problems - rmeove before commit
+  private def logInfo(msg: String) = { println("INFO " + msg) }
+  private def logDebug(msg: String) = { println("DEBUG " + msg) }
 
   /**
    * Create a factory for the given column iterator.

--- a/src/main/scala/shark/memstore2/column/ColumnStats.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnStats.scala
@@ -23,7 +23,7 @@ import java.io.Externalizable
 import java.sql.Timestamp
 
 import org.apache.hadoop.io.Text
-import collection.mutable.{Set, HashSet}
+import it.unimi.dsi.fastutil.ints.IntArraySet
 
 /**
  * Column level statistics, including range (min, max).
@@ -97,7 +97,7 @@ object ColumnStats {
     private var _lastValue = 0
     private var _maxDelta = 0
 
-    var uniques: collection.mutable.Set[Int] = new HashSet()
+    var uniques = new IntArraySet(0)
     protected var uniques_ = uniques // setter protected
     var transitions: Int = 0
     protected var transitions_ = transitions // setter protected
@@ -110,7 +110,7 @@ object ColumnStats {
     override def append(v: Int) {
       if (v > _max) _max = v
       if (v < _min) _min = v
-      uniques += v
+      uniques.add(v)
 
       if (_orderedState == UNINITIALIZED) {
         // First value.
@@ -121,7 +121,7 @@ object ColumnStats {
         // Second value.
         _orderedState = if (v >= _lastValue) ASCENDING else DESCENDING
         _maxDelta = math.abs(v - _lastValue)
-        if(_maxDelta != 0) transitions += 1
+        if (_maxDelta != 0) transitions += 1
         _lastValue = v
       } else if (_orderedState == ASCENDING) {
         if (v < _lastValue) {
@@ -129,7 +129,7 @@ object ColumnStats {
           transitions += 1
         } else {
           if (v - _lastValue > _maxDelta) _maxDelta = v - _lastValue
-          if(_maxDelta != 0) transitions += 1
+          if (_maxDelta != 0) transitions += 1
           _lastValue = v
         }
       } else if (_orderedState == DESCENDING) {
@@ -138,7 +138,7 @@ object ColumnStats {
           transitions += 1
         } else {
           if (_lastValue - v > _maxDelta) _maxDelta = _lastValue - v
-          if(_maxDelta != 0) transitions += 1
+          if (_maxDelta != 0) transitions += 1
           _lastValue = v
         }
       }
@@ -196,9 +196,11 @@ object ColumnStats {
       if (_max == null || v.compareTo(_max) > 0) _max = new Text(v)
       if (_min == null || v.compareTo(_min) < 0) _min = new Text(v)
 
-      if (transitions == 0) { transitions = 1 }
-      else if (_prev == null || v.compareTo(_prev) != 0) { transitions += 1 }
-      else {}
+      if (transitions == 0) { 
+        transitions = 1
+      } else if (_prev == null || v.compareTo(_prev) != 0) {
+        transitions += 1
+      }
 
       if (v == null) { 
         _prev = null
@@ -208,10 +210,12 @@ object ColumnStats {
     }
 
     override def appendNull() {
-      super.appendNull
-      if (transitions == 0) { transitions = 1 }
-      else if (null != _prev) { transitions += 1 }
-      else {}
+      super.appendNull()
+      if (transitions == 0) { 
+        transitions = 1
+      } else if (null != _prev) {
+        transitions += 1 
+      }
       _prev = null
     }
 

--- a/src/main/scala/shark/memstore2/column/CompressionScheme.scala
+++ b/src/main/scala/shark/memstore2/column/CompressionScheme.scala
@@ -1,0 +1,12 @@
+package shark.memstore2.column
+
+/** Enumerated values for compression/encoding schemes for columns.
+  * The convention is to always capitalize when converting from String to CompressionScheme.Value
+  */
+object CompressionScheme extends Enumeration {
+  val None   = Value("None")
+  val Auto   = Value("Auto")
+  val Dict   = Value("Dict")
+  val RLE    = Value("Rle")
+  val LZF    = Value("Lzf")
+}

--- a/src/main/scala/shark/memstore2/column/CompressionScheme.scala
+++ b/src/main/scala/shark/memstore2/column/CompressionScheme.scala
@@ -1,7 +1,26 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 /** Enumerated values for compression/encoding schemes for columns.
   * The convention is to always capitalize when converting from String to CompressionScheme.Value
+  * 
+  * Null BitVector encoding is not a choice here - it is always applied for some column types
   */
 object CompressionScheme extends Enumeration {
   val None   = Value("None")

--- a/src/main/scala/shark/memstore2/column/Dictionary.scala
+++ b/src/main/scala/shark/memstore2/column/Dictionary.scala
@@ -32,7 +32,6 @@ import shark.memstore2.buffer.Unsafe
  */
 
 class Dictionary(uniqueInts: List[Int]){
-  // require(uniqueInts.size != 0 && uniqueInts.size < 256)
 
   // return the Int associated with Byte
   def get(b:Byte) = {

--- a/src/main/scala/shark/memstore2/column/Dictionary.scala
+++ b/src/main/scala/shark/memstore2/column/Dictionary.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import java.nio.ByteBuffer
+import scala.collection.mutable.ListBuffer
+
+import shark.memstore2.buffer.ByteBufferReader
+import shark.memstore2.buffer.Unsafe
+
+/* 
+ * Provide a simple serializer to store dictionaries for compression.
+ * These dictionaries will be serialized in the ByteBuffer so that they can go
+ * between the column builder and column iterator.
+ * 
+ * 
+ */
+
+class Dictionary(uniqueInts: List[Int]){
+  // require(uniqueInts.size != 0 && uniqueInts.size < 256)
+
+  // return the Int associated with Byte
+  def get(b:Byte) = {
+    // Convert byte to index
+    // -128, 128 ===> 0, 256
+    var idx: Int = b
+    if(b < 0)
+      idx = b + 256
+
+    if (idx < 0 || size <= idx)
+      throw new IndexOutOfBoundsException("Index " + idx)
+
+    uniqueInts(idx)
+  }
+
+  // return the Byte representation for Int value
+  def getByte(i: Int): Byte = 
+    uniqueInts.indexOf(i).toByte
+
+  def sizeinbits = {
+    val ret = 32 * (1 + uniqueInts.size) 
+    // println("Need " + ret + " Bytes to store dictionary in memory")
+    ret
+  }
+
+  def size = uniqueInts.size
+}
+
+
+object DictionarySerializer{
+
+  // Append the serialized bytes of the Dictionary into the ByteBuffer.
+  def writeToBuffer(buf: ByteBuffer, bitmap: Dictionary) {
+    // compression size in Bytes
+    // compression dict Bytes
+    buf.putInt(bitmap.sizeinbits/8)
+    var pos: Int = 0
+    while (pos < bitmap.size) {
+      // println("pos was " + pos)
+      buf.putInt(bitmap.get(pos.toByte))
+      pos += 1
+    }
+    buf
+  }
+
+  // Create an Dictionary from the byte buffer.
+  def readFromBuffer(bufReader: ByteBufferReader): Dictionary = {
+
+    val bufferLengthInBytes = bufReader.getInt()
+    
+    val uniqueCount = (bufferLengthInBytes - 4)/4 // 4 Bytes used to store length
+    var uniqueInts = new ListBuffer[Int]()
+    var i = 0
+    while (i < uniqueCount) {
+      uniqueInts += bufReader.getInt()
+      i += 1
+    }
+
+    val bitmap = new Dictionary(uniqueInts.toList)
+    bitmap
+  }
+}

--- a/src/main/scala/shark/memstore2/column/Dictionary.scala
+++ b/src/main/scala/shark/memstore2/column/Dictionary.scala
@@ -34,15 +34,17 @@ import shark.memstore2.buffer.Unsafe
 class Dictionary(uniqueInts: List[Int]){
 
   // return the Int associated with Byte
-  def get(b:Byte) = {
+  def get(b:Byte): Int = {
     // Convert byte to index
     // -128, 128 ===> 0, 256
     var idx: Int = b
-    if(b < 0)
+    if(b < 0) {
       idx = b + 256
+    }
 
-    if (idx < 0 || size <= idx)
+    if (idx < 0 || size <= idx) {
       throw new IndexOutOfBoundsException("Index " + idx)
+    }
 
     uniqueInts(idx)
   }

--- a/src/main/scala/shark/memstore2/column/Dictionary.scala
+++ b/src/main/scala/shark/memstore2/column/Dictionary.scala
@@ -23,7 +23,6 @@ import org.apache.hadoop.io.Text
 import org.apache.hadoop.io.IntWritable
 
 import shark.memstore2.buffer.ByteBufferReader
-import shark.memstore2.buffer.Unsafe
 
 /** Provide a simple serializer to store dictionaries for compression.  These
  * dictionaries will be serialized in the ByteBuffer so that they can go between
@@ -100,16 +99,18 @@ object DictionarySerializer{
     buf.putInt(bitmap.sizeInBits/8)
     var pos: Int = 0
     while (pos < bitmap.size) {
-      // println("writetobuffer: pos was " + pos + " sizeInBits/8 " + bitmap.sizeInBits/8)
+      // println("writetobuffer: pos was " + pos + 
+      //   " sizeInBits/8 " + bitmap.sizeInBits/8 + 
+      //   " bitmap.size " + bitmap.size)
       buf.putInt(bitmap.get(pos.toByte))
       pos += 1
     }
-    // println("buf pos was " + buf.position)
     buf
   }
 
   // Create a Dictionary from the byte buffer.
   def readFromBuffer(bufReader: ByteBufferReader): Dictionary[Int] = {
+    // println("bufReader.position before dict  " + bufReader.position)
 
     val bufferLengthInBytes = bufReader.getInt()
     

--- a/src/main/scala/shark/memstore2/column/Dictionary.scala
+++ b/src/main/scala/shark/memstore2/column/Dictionary.scala
@@ -43,11 +43,13 @@ trait Dictionary[@specialized(Int) T]{
 /** Int implementation. Saves space by using 1 byte per Int
   * instead of 4.
   */
-class IntDictionary extends Dictionary[Int]{
+class IntDictionary extends Dictionary[Int] {
   var uniques = new Array[Int](0)
   private var writable = new IntWritable
 
   override def initialize(u: Array[Int]) = {
+    require(u.size < DictionarySerializer.MAX_DICT_UNIQUE_VALUES, 
+      "Too many unique values to build an IntDictionary " + u.size)
     uniques = new Array[Int](u.size)
     u.copyToArray(uniques)
   }
@@ -91,6 +93,9 @@ class IntDictionary extends Dictionary[Int]{
 /** Helper to share code betwen the Iterator and various Builders.
   */
 object DictionarySerializer{
+  // Dictionaries can only work when number of unique values is lower than this. Values should fit
+  // in Bytes.
+  val MAX_DICT_UNIQUE_VALUES = 256 // 2 ** 8 - storable in 8 bits or 1 Byte
 
   // Append the serialized bytes of the Dictionary into the ByteBuffer.
   def writeToBuffer(buf: ByteBuffer, bitmap: IntDictionary) {

--- a/src/main/scala/shark/memstore2/column/Dictionary.scala
+++ b/src/main/scala/shark/memstore2/column/Dictionary.scala
@@ -25,14 +25,11 @@ import org.apache.hadoop.io.IntWritable
 import shark.memstore2.buffer.ByteBufferReader
 import shark.memstore2.buffer.Unsafe
 
-/* 
- * Provide a simple serializer to store dictionaries for compression.
- * These dictionaries will be serialized in the ByteBuffer so that they can go
- * between the column builder and column iterator.
- * 
+/** Provide a simple serializer to store dictionaries for compression.  These
+ * dictionaries will be serialized in the ByteBuffer so that they can go between
+ * the column builder and column iterator.
  * 
  */
-
 trait Dictionary[@specialized(Int) T]{
   var uniques: Array[T]
   def initialize(u: List[T]): Unit
@@ -44,6 +41,9 @@ trait Dictionary[@specialized(Int) T]{
 }
 
 
+/** Int implementation. Saves space by using 1 byte per Int
+  * instead of 4.
+  */
 class IntDictionary extends Dictionary[Int]{
   var uniques = new Array[Int](0)
   override def initialize(u: List[Int]) = {
@@ -86,7 +86,8 @@ class IntDictionary extends Dictionary[Int]{
 
 // }
 
-
+/** Helper to share code betwen the Iterator and various Builders.
+  */
 object DictionarySerializer{
 
   // Append the serialized bytes of the Dictionary into the ByteBuffer.

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
@@ -21,13 +21,12 @@ import shark.memstore2.buffer.ByteBufferReader
 import org.apache.hadoop.io
 
 
-/**
-  * A wrapper around any ColumnIterator so it can be Dictionary Encoded
+/** A wrapper around any ColumnIterator so it can be Dictionary Encoded
+  * Bytes storing the dictionary come first in the buffer.
   * 
-  *  Bytes storing the dictionary come first in the buffer.
-  * 
+  * Class not actually being used. Was an attempt to build a type-agnostic
+  * dictionary encoding rather than multiple type-specific ones.
   */
-
 class DictionaryEncodedColumnIterator[Iter <: ColumnIterator](baseIterCls: Class[Iter], _bytesReader: ByteBufferReader)
     extends ColumnIterator{
   private var currentByte: Byte = 0

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
@@ -48,7 +48,7 @@ class DictionaryEncodedColumnIterator[Iter <: ColumnIterator](baseIterCls: Class
   override def current: Object = {
     if (!initialized) {
       // require(initialized == true)
-      throw new RuntimeException("RLEColumnIterator next() should be called first")
+      throw new RuntimeException("DictionaryEncodedColumnIterator next() should be called first")
     } else {
       _dict.getWritable(currentByte)
     }

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
@@ -31,7 +31,7 @@ class DictionaryEncodedColumnIterator[Iter <: ColumnIterator](baseIterCls: Class
     extends ColumnIterator{
   private var currentByte: Byte = 0
   private var initialized =  false
-  private val _dict = DictionarySerializer.readFromBuffer(_bytesReader)
+  private val _dict = IntDictionarySerializer.readFromBuffer(_bytesReader)
   // order matters - dict should be built first
   // private val baseIter: Iter = {
   //   val ctor = baseIterCls.getConstructor(classOf[ByteBufferReader])

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
@@ -21,8 +21,6 @@ import shark.memstore2.buffer.ByteBufferReader
 import org.apache.hadoop.io
 
 
-import shark.LogHelper
-
 /**
   * A wrapper around any ColumnIterator so it can be Dictionary Encoded
   * 

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedColumnIterator.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import shark.memstore2.buffer.ByteBufferReader
+import org.apache.hadoop.io
+
+
+import shark.LogHelper
+
+/**
+  * A wrapper around any ColumnIterator so it can be Dictionary Encoded
+  * 
+  *  Bytes storing the dictionary come first in the buffer.
+  * 
+  */
+
+class DictionaryEncodedColumnIterator[Iter <: ColumnIterator](baseIterCls: Class[Iter], _bytesReader: ByteBufferReader)
+    extends ColumnIterator{
+  private var currentByte: Byte = 0
+  private var initialized =  false
+  private val _dict = DictionarySerializer.readFromBuffer(_bytesReader)
+  // order matters - dict should be built first
+  // private val baseIter: Iter = {
+  //   val ctor = baseIterCls.getConstructor(classOf[ByteBufferReader])
+  //   ctor.newInstance(_bytesReader).asInstanceOf[Iter]
+  // }
+
+
+  override def next() {
+    initialized = true
+    currentByte = _bytesReader.getByte()
+  }
+
+  // Semantics are to not change state - read-only
+  override def current: Object = {
+    if (!initialized) {
+      // require(initialized == true)
+      throw new RuntimeException("RLEColumnIterator next() should be called first")
+    } else {
+      _dict.getWritable(currentByte)
+    }
+  }
+
+}

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedIntColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedIntColumnIterator.scala
@@ -23,6 +23,9 @@ import shark.memstore2.buffer.ByteBufferReader
 import shark.memstore2.column
 
 
+/** An iterator for Ints that are Dict encoded. Bytes storing the dictionary
+  * come first in the buffer.
+  */
 object DictionaryEncodedIntColumnIterator{
 
   sealed class Default(private val _bytesReader: ByteBufferReader) extends ColumnIterator {

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedIntColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedIntColumnIterator.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import org.apache.hadoop.io.IntWritable
+
+import shark.memstore2.buffer.ByteBufferReader
+import shark.memstore2.column
+
+
+object DictionaryEncodedIntColumnIterator{
+
+  sealed class Default(private val _bytesReader: ByteBufferReader) extends ColumnIterator {
+    private val _writable = new IntWritable
+    private val _dict = DictionarySerializer.readFromBuffer(_bytesReader)
+
+    override def next() {
+      _writable.set(_dict.get(_bytesReader.getByte()))
+    }
+
+    override def current = _writable
+  }
+}

--- a/src/main/scala/shark/memstore2/column/DictionaryEncodedIntColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/DictionaryEncodedIntColumnIterator.scala
@@ -30,7 +30,7 @@ object DictionaryEncodedIntColumnIterator{
 
   sealed class Default(private val _bytesReader: ByteBufferReader) extends ColumnIterator {
     private val _writable = new IntWritable
-    private val _dict = DictionarySerializer.readFromBuffer(_bytesReader)
+    private val _dict = IntDictionarySerializer.readFromBuffer(_bytesReader)
 
     override def next() {
       _writable.set(_dict.get(_bytesReader.getByte()))

--- a/src/main/scala/shark/memstore2/column/DoubleColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/DoubleColumnBuilder.scala
@@ -29,10 +29,10 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspe
 class DoubleColumnBuilder extends ColumnBuilder[Double] {
 
   private var _stats: ColumnStats.DoubleColumnStats = null
-  private var _arr: DoubleArrayList = null
+  private var _nonNulls: DoubleArrayList = null
 
   override def initialize(initialSize: Int) {
-    _arr = new DoubleArrayList(initialSize)
+    _nonNulls = new DoubleArrayList(initialSize)
     _stats = new ColumnStats.DoubleColumnStats
     super.initialize(initialSize)
   }
@@ -47,13 +47,12 @@ class DoubleColumnBuilder extends ColumnBuilder[Double] {
   }
 
   override def append(v: Double) {
-    _arr.add(v)
+    _nonNulls.add(v)
     _stats.append(v)
   }
 
   override def appendNull() {
-    _nullBitmap.set(_arr.size)
-    _arr.add(0)
+    _nullBitmap.set(_nonNulls.size + _stats.nullCount)
     _stats.appendNull()
   }
 
@@ -61,15 +60,15 @@ class DoubleColumnBuilder extends ColumnBuilder[Double] {
 
   override def build: ByteBuffer = {
     val buf = ByteBuffer.allocate(
-      _arr.size * 8 + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
+      _nonNulls.size * 8 + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
     buf.order(ByteOrder.nativeOrder())
     buf.putLong(ColumnIterator.DOUBLE)
 
     writeNullBitmap(buf)
 
     var i = 0
-    while (i < _arr.size) {
-      buf.putDouble(_arr.get(i))
+    while (i < _nonNulls.size) {
+      buf.putDouble(_nonNulls.get(i))
       i += 1
     }
     buf.rewind()

--- a/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
@@ -68,10 +68,11 @@ class EWAHNullableColumnIterator[T <: ColumnIterator](
     _pos += 1
     // println(" _nextNullPosition " + _nextNullPosition + " ][ _pos " + _pos)
 
-    if(_pos == _nextNullPosition)
+    if (_pos == _nextNullPosition) {
       null
-    else
+    } else {
       baseIter.next()
+    }
   }
 
   // Semantics are to not change state - read-only

--- a/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
@@ -61,7 +61,7 @@ class EWAHNullableColumnIterator[T <: ColumnIterator](bIter: T, bytes: ByteBuffe
     if (_pos >= _nextNullPosition || _pos == -1) {
       if (_nullsIter.hasNext) {
         _nextNullPosition = _nullsIter.next
-      } 
+      }
     }
 
     _pos += 1

--- a/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
@@ -24,9 +24,10 @@ import javaewah.IntIterator
 import shark.memstore2.buffer.ByteBufferReader
 
 
-/**
- * A wrapper around non-null ColumnIterator so it can handle null values.
- */
+/** Wrapper around Concrete ColumnIterators so they can handle null values.
+  * The Null Bit Vector is maintained in the first part of the Buffer.
+  * Can be composed with other wrappers like the [[shark.memstore2.column.RLEColumnIterator]]
+  */
 class EWAHNullableColumnIterator[T <: ColumnIterator](
     bIter: T, bytes: ByteBufferReader)
   extends ColumnIterator {

--- a/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/EWAHNullableColumnIterator.scala
@@ -31,10 +31,18 @@ class EWAHNullableColumnIterator[T <: ColumnIterator](
     baseIterCls: Class[T], bytes: ByteBufferReader)
   extends ColumnIterator {
 
-  val _nullBitmap: EWAHCompressedBitmap = EWAHCompressedBitmapSerializer.readFromBuffer(bytes)
+  val _nullBitmap: EWAHCompressedBitmap =
+  EWAHCompressedBitmapSerializer.readFromBuffer(bytes)
+
+  /*
+   *  The location of the null bits is returned, in increasing order through
+   *  _nullsIter
+   */
   val _nullsIter: IntIterator = _nullBitmap.intIterator
+
   var _pos = -1
   var _nextNullPosition = -1
+  private var currentNull = false
 
   val baseIter: T = {
     val ctor = baseIterCls.getConstructor(classOf[ByteBufferReader])
@@ -42,14 +50,26 @@ class EWAHNullableColumnIterator[T <: ColumnIterator](
   }
 
   override def next() {
+    if (_pos >= _nextNullPosition || _pos == -1) {
+      if (_nullsIter.hasNext) {
+        _nextNullPosition = _nullsIter.next
+      } 
+    }
+
+    // println("EWAH Nullable next() called")
+
     _pos += 1
-    baseIter.next()
+    // println(" _nextNullPosition " + _nextNullPosition + " ][ _pos " + _pos)
+
+    if(_pos == _nextNullPosition)
+      null
+    else
+      baseIter.next()
   }
 
+  // Semantics are to not change state - read-only
   override def current: Object = {
-    while (_nextNullPosition < _pos && _nullsIter.hasNext) _nextNullPosition = _nullsIter.next
     if (_nextNullPosition == _pos) {
-      _nextNullPosition = if (_nullsIter.hasNext) _nullsIter.next else Int.MaxValue
       null
     } else {
       baseIter.current

--- a/src/main/scala/shark/memstore2/column/FloatColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/FloatColumnBuilder.scala
@@ -29,10 +29,10 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspec
 class FloatColumnBuilder extends ColumnBuilder[Float] {
 
   private var _stats: ColumnStats.FloatColumnStats = null
-  private var _arr: FloatArrayList = null
+  private var _nonNulls: FloatArrayList = null
 
   override def initialize(initialSize: Int) {
-    _arr = new FloatArrayList(initialSize)
+    _nonNulls = new FloatArrayList(initialSize)
     _stats = new ColumnStats.FloatColumnStats
     super.initialize(initialSize)
   }
@@ -47,13 +47,12 @@ class FloatColumnBuilder extends ColumnBuilder[Float] {
   }
 
   override def append(v: Float) {
-    _arr.add(v)
+    _nonNulls.add(v)
     _stats.append(v)
   }
 
   override def appendNull() {
-    _nullBitmap.set(_arr.size)
-    _arr.add(0)
+    _nullBitmap.set(_nonNulls.size + _stats.nullCount)
     _stats.appendNull()
   }
 
@@ -61,15 +60,15 @@ class FloatColumnBuilder extends ColumnBuilder[Float] {
 
   override def build: ByteBuffer = {
     val buf = ByteBuffer.allocate(
-      _arr.size * 4 + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
+      _nonNulls.size * 4 + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
     buf.order(ByteOrder.nativeOrder())
     buf.putLong(ColumnIterator.FLOAT)
 
     writeNullBitmap(buf)
 
     var i = 0
-    while (i < _arr.size) {
-      buf.putFloat(_arr.get(i))
+    while (i < _nonNulls.size) {
+      buf.putFloat(_nonNulls.get(i))
       i += 1
     }
     buf.rewind()

--- a/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
@@ -131,8 +131,10 @@ class IntColumnBuilder extends ColumnBuilder[Int]{
           i += 1
         }
 
-        val runs = rleSs.getCoded map (_._1)
-        val vals = rleSs.getCoded map (_._2)
+        val rleStrings = rleSs.getCoded
+        val vals = rleStrings map (_._2)
+        val runs = new IntArrayList(vals.size)
+        rleStrings.foreach ( x => runs.add(x._1) )
 
         val minbufsize = 
           4 + //#runs
@@ -197,7 +199,7 @@ class IntColumnBuilder extends ColumnBuilder[Int]{
         buf
       }
       case _ => throw new IllegalArgumentException(
-        "scheme muse be one of auto, none, RLE, dict")
+        "scheme must be one of auto, none, RLE, dict")
     } // match
 
   }

--- a/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
@@ -27,6 +27,9 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspecto
 
 import collection.mutable.{Set, HashSet}
 
+
+/** Build a column of Int values into a ByteBuffer in memory.
+  */
 class IntColumnBuilder extends ColumnBuilder[Int]{
 
   // logger problems - rmeove before commit
@@ -94,6 +97,9 @@ class IntColumnBuilder extends ColumnBuilder[Int]{
 
   var scheme = "auto"
 
+  /** After all values have been appended, build() is called to write all the
+    * values into a ByteBuffer.
+    */
   override def build: ByteBuffer = {
 
     scheme = System.getenv("TEST_SHARK_INT_COLUMN_COMPRESSION_SCHEME")

--- a/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
@@ -167,7 +167,7 @@ class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
       case "DICT" => {
         val dict = new IntDictionary
         logInfo("#uniques " + _stats.uniques.size)
-        dict.initialize(_stats.uniques.toList)
+        dict.initialize(_stats.uniques.toIntArray)
         val minbufsize = (_nonNulls.size*1) + ColumnIterator.COLUMN_TYPE_LENGTH +
         sizeOfNullBitmap + (dict.sizeInBits/8)
 

--- a/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
@@ -37,8 +37,7 @@ class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
   private var _uniques: collection.mutable.Set[Int] = new HashSet()
   // compressionPossible is true by default but becomes false after there are
   // more than MAX_UNIQUE_VALUES.
-  private var compressionPossible = true
-  def isCompressed = compressionPossible
+  var compressionPossible = true
 
   override def initialize(initialSize: Int) {
     _nonNulls = new IntArrayList(initialSize)
@@ -98,16 +97,18 @@ class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
       }
       buf.rewind()
       buf
-    }
-    else { // compressionPossible = true
-      val dict = new Dictionary(_uniques.toList)
+    } else { // compressionPossible = true
+      val dict = new IntDictionary
+      logInfo("#uniques " + _uniques.size) 
+      dict.initialize(_uniques.toList)
       val minbufsize = (_nonNulls.size*1) + ColumnIterator.COLUMN_TYPE_LENGTH +
-        sizeOfNullBitmap + (dict.sizeinbits/8)
+        sizeOfNullBitmap + (dict.sizeInBits/8)
 
-      logDebug(" dict.sizeinbits/8 " + (dict.sizeinbits/8) +
-        " sizeOfNullBitmap " + sizeOfNullBitmap +
+      logInfo(
         " ColumnIterator.COLUMN_TYPE_LENGTH " +
         ColumnIterator.COLUMN_TYPE_LENGTH +
+        " sizeOfNullBitmap " + sizeOfNullBitmap +
+        " dict.sizeinbits/8 " + (dict.sizeInBits/8) +
         " _nonNulls.size*1 " + _nonNulls.size*1)
 
       val buf = ByteBuffer.allocate(minbufsize)

--- a/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
@@ -27,17 +27,27 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspecto
 
 import collection.mutable.{Set, HashSet}
 
-import shark.LogHelper
+class IntColumnBuilder extends ColumnBuilder[Int]{
 
-class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
+  // logger problems - rmeove before commit
+  private def logInfo(msg: String) = { println("INFO " + msg) }
+  private def logDebug(msg: String) = { println("DEBUG " + msg) }
 
   private var _stats: ColumnStats.IntColumnStats = new ColumnStats.IntColumnStats
   private var _nonNulls: IntArrayList = null
   private val MAX_UNIQUE_VALUES = 256 // 2 ** 8 - storable in 8 bits or 1 Byte
 
   override def initialize(initialSize: Int) {
+    initialize(initialSize, "auto", "auto")
+  }
+
+  override def initialize(initialSize: Int,
+    columnarComprString: String,
+    columnarComprInt: String) {
+
     _nonNulls = new IntArrayList(initialSize)
     _stats = new ColumnStats.IntColumnStats
+    scheme = columnarComprInt
     super.initialize(initialSize)
   }
 
@@ -82,9 +92,11 @@ class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
   }
 
 
+  var scheme = "auto"
+
   override def build: ByteBuffer = {
 
-    var scheme = System.getenv("TEST_SHARK_INT_COLUMN_COMPRESSION_SCHEME")
+    scheme = System.getenv("TEST_SHARK_INT_COLUMN_COMPRESSION_SCHEME")
     if(scheme == null || scheme == "auto") scheme = pickCompressionScheme
     // choices are none, auto, RLE, dict
 

--- a/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
@@ -26,31 +26,18 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector
 
 import collection.mutable.{Set, HashSet}
-
+import shark.LogHelper
 
 /** Build a column of Int values into a ByteBuffer in memory.
   */
-class IntColumnBuilder extends ColumnBuilder[Int]{
-
-  // logger problems - rmeove before commit
-  private def logInfo(msg: String) = { println("INFO " + msg) }
-  private def logDebug(msg: String) = { println("DEBUG " + msg) }
-
+class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
   private var _stats: ColumnStats.IntColumnStats = new ColumnStats.IntColumnStats
   private var _nonNulls: IntArrayList = null
   private val MAX_UNIQUE_VALUES = 256 // 2 ** 8 - storable in 8 bits or 1 Byte
 
   override def initialize(initialSize: Int) {
-    initialize(initialSize, "auto", "auto")
-  }
-
-  override def initialize(initialSize: Int,
-    columnarComprString: String,
-    columnarComprInt: String) {
-
     _nonNulls = new IntArrayList(initialSize)
     _stats = new ColumnStats.IntColumnStats
-    scheme = columnarComprInt
     super.initialize(initialSize)
   }
 
@@ -81,10 +68,6 @@ class IntColumnBuilder extends ColumnBuilder[Int]{
     // ratio of transitions < 50% (run+value is 2 ints instead of 1)
     val selectivity = (_stats.uniques.size).toDouble / _nonNulls.size
     val transitionsRatio = (_stats.transitions).toDouble / _nonNulls.size
-    logInfo("uniques=" + _stats.uniques.size + " selectivity=" + selectivity + 
-      " transitionsRatio=" + transitionsRatio + 
-      " transitions=" + _stats.transitions +
-      " #values=" + _nonNulls.size)
 
     if(selectivity < 0.2) {
       if (transitionsRatio < 0.5) return "RLE"
@@ -95,16 +78,27 @@ class IntColumnBuilder extends ColumnBuilder[Int]{
   }
 
 
-  var scheme = "auto"
-
   /** After all values have been appended, build() is called to write all the
     * values into a ByteBuffer.
     */
   override def build: ByteBuffer = {
+    logDebug("scheme at the start of build() was " + scheme)
 
-    scheme = System.getenv("TEST_SHARK_INT_COLUMN_COMPRESSION_SCHEME")
+    // highest priority override is if someone (like a test) calls the getter
+    //.scheme()
+
+    // next priority override - from TBL PROPERTIES
+
     if(scheme == null || scheme == "auto") scheme = pickCompressionScheme
     // choices are none, auto, RLE, dict
+
+    val selectivity = (_stats.uniques.size).toDouble / _nonNulls.size
+    val transitionsRatio = (_stats.transitions).toDouble / _nonNulls.size
+    logInfo("uniques=" + _stats.uniques.size + " selectivity=" + selectivity + 
+      " transitionsRatio=" + transitionsRatio + 
+      " transitions=" + _stats.transitions +
+      " #values=" + _nonNulls.size)
+
 
     scheme.toUpperCase match {
       case "NONE" => {

--- a/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/IntColumnBuilder.scala
@@ -31,13 +31,9 @@ import shark.LogHelper
 
 class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
 
-  private var _stats: ColumnStats.IntColumnStats = null
+  private var _stats: ColumnStats.IntColumnStats = new ColumnStats.IntColumnStats
   private var _nonNulls: IntArrayList = null
   private val MAX_UNIQUE_VALUES = 256 // 2 ** 8 - storable in 8 bits or 1 Byte
-  private var _uniques: collection.mutable.Set[Int] = new HashSet()
-  // compressionPossible is true by default but becomes false after there are
-  // more than MAX_UNIQUE_VALUES.
-  var compressionPossible = true
 
   override def initialize(initialSize: Int) {
     _nonNulls = new IntArrayList(initialSize)
@@ -57,13 +53,6 @@ class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
   override def append(v: Int) {
     _nonNulls.add(v)
     _stats.append(v)
-    // compressionPossible is used to short-circuit adding elements to _uniques
-    // if there are too many elements
-    if (compressionPossible) {
-      _uniques += v
-      if (_uniques.size >= MAX_UNIQUE_VALUES) 
-        compressionPossible = false
-    }
   }
 
   override def appendNull() {
@@ -73,64 +62,131 @@ class IntColumnBuilder extends ColumnBuilder[Int] with LogHelper{
 
   override def stats = _stats
 
+  def pickCompressionScheme: String = {
+    // RLE choice logic - use RLE if the
+    // selectivity is < 20% &&
+    // ratio of transitions < 50% (run+value is 2 ints instead of 1)
+    val selectivity = (_stats.uniques.size).toDouble / _nonNulls.size
+    val transitionsRatio = (_stats.transitions).toDouble / _nonNulls.size
+    logInfo("uniques=" + _stats.uniques.size + " selectivity=" + selectivity + 
+      " transitionsRatio=" + transitionsRatio + 
+      " transitions=" + _stats.transitions +
+      " #values=" + _nonNulls.size)
+
+    if(selectivity < 0.2) {
+      if (transitionsRatio < 0.5) return "RLE"
+      else return "dict"
+    } else {
+      return "none"
+    }
+  }
+
+
   override def build: ByteBuffer = {
-    logDebug("IntColumnBuilder " + _uniques.size + " unique values")
-    if (!compressionPossible) {
-      val minbufsize = (_nonNulls.size*4) + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap
-      val buf = ByteBuffer.allocate(minbufsize)
-      logDebug("sizeOfNullBitmap " + sizeOfNullBitmap +
-        " ColumnIterator.COLUMN_TYPE_LENGTH " +
-        ColumnIterator.COLUMN_TYPE_LENGTH +
-        " _nonNulls.size*4 " + _nonNulls.size*4)
-      logInfo("Allocated ByteBuffer of size " + minbufsize)
 
+    var scheme = System.getenv("TEST_SHARK_INT_COLUMN_COMPRESSION_SCHEME")
+    if(scheme == null || scheme == "auto") scheme = pickCompressionScheme
+    // choices are none, auto, RLE, dict
 
-      buf.order(ByteOrder.nativeOrder())
-      buf.putLong(ColumnIterator.INT)
+    scheme.toUpperCase match {
+      case "NONE" => {
+        val minbufsize = (_nonNulls.size*4) + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap
+        val buf = ByteBuffer.allocate(minbufsize)
+        logDebug("sizeOfNullBitmap " + sizeOfNullBitmap +
+          " ColumnIterator.COLUMN_TYPE_LENGTH " +
+          ColumnIterator.COLUMN_TYPE_LENGTH +
+          " _nonNulls.size*4 " + _nonNulls.size*4)
+        logInfo("Allocated ByteBuffer of scheme " + scheme + " size " + minbufsize)
 
-      writeNullBitmap(buf)
+        buf.order(ByteOrder.nativeOrder())
+        buf.putLong(ColumnIterator.INT)
 
-      var i = 0
-      while (i < _nonNulls.size) {
-        buf.putInt(_nonNulls.get(i))
-        i += 1
+        writeNullBitmap(buf)
+
+        var i = 0
+        while (i < _nonNulls.size) {
+          buf.putInt(_nonNulls.get(i))
+          i += 1
+        }
+        buf.rewind()
+        buf
+      } 
+      case "RLE" => {
+        var rleSs = new RLEStreamingSerializer[Int]( { () => -1 } )
+        var i = 0
+        while (i < _nonNulls.size) {
+          rleSs.encodeSingle(_nonNulls.get(i))
+          i += 1
+        }
+
+        val runs = rleSs.getCoded map (_._1)
+        val vals = rleSs.getCoded map (_._2)
+
+        val minbufsize = 
+          4 + //#runs
+          runs.size*4 + //runs
+          runs.size*4 + //values
+          ColumnIterator.COLUMN_TYPE_LENGTH +
+          sizeOfNullBitmap
+
+        val buf = ByteBuffer.allocate(minbufsize)
+        buf.order(ByteOrder.nativeOrder())
+        buf.putLong(ColumnIterator.RLE_INT)
+
+        logDebug("sizeOfNullBitmap " + sizeOfNullBitmap +
+          " ColumnIterator.COLUMN_TYPE_LENGTH " +
+          ColumnIterator.COLUMN_TYPE_LENGTH +
+          " runs.size*8 " + runs.size*8)
+        logInfo("Allocated ByteBuffer of scheme " + scheme + " size " + minbufsize)
+
+        writeNullBitmap(buf)
+        RLESerializer.writeToBuffer(buf, runs)
+
+        // after writing runs, write values
+        vals.foreach { 
+          buf.putInt(_)
+        }
+
+        buf.rewind()
+        buf
       }
-      buf.rewind()
-      buf
-    } else { // compressionPossible = true
-      val dict = new IntDictionary
-      logInfo("#uniques " + _uniques.size) 
-      dict.initialize(_uniques.toList)
-      val minbufsize = (_nonNulls.size*1) + ColumnIterator.COLUMN_TYPE_LENGTH +
+      case "DICT" => {
+        val dict = new IntDictionary
+        logInfo("#uniques " + _stats.uniques.size)
+        dict.initialize(_stats.uniques.toList)
+        val minbufsize = (_nonNulls.size*1) + ColumnIterator.COLUMN_TYPE_LENGTH +
         sizeOfNullBitmap + (dict.sizeInBits/8)
 
-      logInfo(
-        " ColumnIterator.COLUMN_TYPE_LENGTH " +
-        ColumnIterator.COLUMN_TYPE_LENGTH +
-        " sizeOfNullBitmap " + sizeOfNullBitmap +
-        " dict.sizeinbits/8 " + (dict.sizeInBits/8) +
-        " _nonNulls.size*1 " + _nonNulls.size*1)
+        logInfo(
+          " ColumnIterator.COLUMN_TYPE_LENGTH " +
+            ColumnIterator.COLUMN_TYPE_LENGTH +
+            " sizeOfNullBitmap " + sizeOfNullBitmap +
+            " dict.sizeinbits/8 " + (dict.sizeInBits/8) +
+            " _nonNulls.size*1 " + _nonNulls.size*1)
 
-      val buf = ByteBuffer.allocate(minbufsize)
-      logInfo("Allocated ByteBuffer (compressed) of size " + minbufsize)
+        val buf = ByteBuffer.allocate(minbufsize)
+        logInfo("Allocated ByteBuffer of scheme " + scheme + " size " + minbufsize)
+        buf.order(ByteOrder.nativeOrder())
+        buf.putLong(ColumnIterator.DICT_INT)
 
-      buf.order(ByteOrder.nativeOrder())
-      buf.putLong(ColumnIterator.DICT_INT)
+        writeNullBitmap(buf)
 
-      writeNullBitmap(buf)
+        DictionarySerializer.writeToBuffer(buf, dict)
 
-      DictionarySerializer.writeToBuffer(buf, dict)
-
-      var i = 0
-      while (i < _nonNulls.size) {
-        buf.put(dict.getByte(_nonNulls.get(i)))
-        i += 1
+        var i = 0
+        while (i < _nonNulls.size) {
+          buf.put(dict.getByte(_nonNulls.get(i)))
+          i += 1
+        }
+        logInfo("Compression ratio is " +
+          (_nonNulls.size.toFloat*4/(minbufsize)) +
+          " : 1")
+        buf.rewind()
+        buf
       }
-      logInfo("Compression ratio is " + 
-        (_nonNulls.size.toFloat*4/(minbufsize)) +
-        " : 1")
-      buf.rewind()
-      buf
-    }
+      case _ => throw new IllegalArgumentException(
+        "scheme muse be one of auto, none, RLE, dict")
+    } // match
+
   }
 }

--- a/src/main/scala/shark/memstore2/column/LZFBlockColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/LZFBlockColumnIterator.scala
@@ -30,8 +30,6 @@ import com.ning.compress.lzf.LZFOutputStream
 import com.ning.compress.lzf.LZFEncoder
 import com.ning.compress.lzf.LZFDecoder
 
-import shark.LogHelper
-
 /**
  * A wrapper that uses LZ compression. Decompresses in blocks (or chunks) so
  * that large amounts of scratch space will not required for large columns. LZF

--- a/src/main/scala/shark/memstore2/column/LZFBlockColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/LZFBlockColumnIterator.scala
@@ -83,7 +83,7 @@ class LZFBlockColumnIterator[T <: ColumnIterator](
     }
   }
 
-  override def next = {
+  override def next() {
     initialized = true
     (rowCount % LZFSerializer.BLOCK_SIZE) match {
       case 0 => {     // may need new chunk - get that and populate BB

--- a/src/main/scala/shark/memstore2/column/LZFBlockColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/LZFBlockColumnIterator.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import scala.collection.mutable._
+import shark.memstore2.buffer.ByteBufferReader
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.io.InputStream
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+import com.ning.compress.lzf.LZFInputStream
+import com.ning.compress.lzf.LZFOutputStream
+import com.ning.compress.lzf.LZFEncoder
+import com.ning.compress.lzf.LZFDecoder
+
+import shark.LogHelper
+
+/**
+ * A wrapper that uses LZ compression. Decompresses in blocks (or chunks) so
+ * that large amounts of scratch space will not required for large columns. LZF
+ * is a chunk-based algorithm in any case.
+ */
+
+
+class LZFBlockColumnIterator[T <: ColumnIterator](
+  baseIterCls: Class[T], bytes: ByteBufferReader)
+    extends ColumnIterator {
+
+  var initialized = false
+  var (numUncompressedBytes, compressedArr) = LZFSerializer.readFromBuffer(bytes)
+  // use a safe larger size
+  val minChunkSize = math.max(LZFSerializer.MIN_CHUNK_BYTES, 2*LZFSerializer.BLOCK_SIZE)
+  val uncompressedArr = new Array[Byte](minChunkSize)
+
+  val bis: ByteArrayInputStream = new ByteArrayInputStream(compressedArr)
+  val is: InputStream = new LZFInputStream(bis)
+
+  val uncompressedBB = ByteBuffer.allocate(numUncompressedBytes)
+  // logDebug("numUncompressedBytes " + numUncompressedBytes)
+  uncompressedBB.order(ByteOrder.nativeOrder())
+
+  val baseIter: T = {
+    val ctor = baseIterCls.getConstructor(classOf[ByteBufferReader])
+    val uncompressedBBR = ByteBufferReader.createUnsafeReader(uncompressedBB)
+    ctor.newInstance(uncompressedBBR).asInstanceOf[T]
+  }
+
+
+  var rowCount = 0
+  override def next = {
+    initialized = true
+    (rowCount % LZFSerializer.BLOCK_SIZE) match {
+      case 0 => {     // may need new chunk - get that and populate BB
+        val num = is.read(uncompressedArr)
+        if(num > 0) {
+          uncompressedBB.put(uncompressedArr, 0, num)
+        } else {
+          null // no elements
+        }
+      }
+      case _ => {
+        // do nothing - chunk populated
+      }
+    }
+
+    rowCount += 1
+    baseIter.next()
+  }
+
+  // Semantics are to not change state - read-only
+  override def current: Object = {
+    if (!initialized) {
+      throw new RuntimeException("LZFBlockColumnIterator next() should be called first")
+    } else {
+      baseIter.current
+    }
+  }
+}

--- a/src/main/scala/shark/memstore2/column/LZFColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/LZFColumnIterator.scala
@@ -23,7 +23,8 @@ import java.nio.ByteBuffer
 
 
 /**
- * A wrapper that uses LZ compression
+ * A wrapper that uses LZ compression. Decompresses in one shot requiring a lot
+ * of memory to store the uncompressed data.
  */
 
 
@@ -32,7 +33,7 @@ class LZFColumnIterator[T <: ColumnIterator](
     extends ColumnIterator {
 
   var initialized = false
-  val compressedArr = LZFSerializer.readFromBuffer(bytes)
+  val (num, compressedArr) = LZFSerializer.readFromBuffer(bytes)
   val uncompressedArr = LZFSerializer.decode(compressedArr)
   val uncompressedBytes = ByteBuffer.wrap(uncompressedArr)
   val baseIter: T = {

--- a/src/main/scala/shark/memstore2/column/LZFColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/LZFColumnIterator.scala
@@ -42,7 +42,7 @@ class LZFColumnIterator[T <: ColumnIterator](
     ctor.newInstance(uncompressedBBR).asInstanceOf[T]
   }
 
-  override def next = {
+  override def next() {
     initialized = true
     baseIter.next()
   }

--- a/src/main/scala/shark/memstore2/column/LZFColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/LZFColumnIterator.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import scala.collection.mutable._
+import shark.memstore2.buffer.ByteBufferReader
+import java.nio.ByteBuffer
+
+
+/**
+ * A wrapper that uses LZ compression
+ */
+
+
+class LZFColumnIterator[T <: ColumnIterator](
+  baseIterCls: Class[T], bytes: ByteBufferReader)
+    extends ColumnIterator {
+
+  var initialized = false
+  val compressedArr = LZFSerializer.readFromBuffer(bytes)
+  val uncompressedArr = LZFSerializer.decode(compressedArr)
+  val uncompressedBytes = ByteBuffer.wrap(uncompressedArr)
+  val baseIter: T = {
+    val ctor = baseIterCls.getConstructor(classOf[ByteBufferReader])
+    val uncompressedBBR = ByteBufferReader.createUnsafeReader(uncompressedBytes)
+    ctor.newInstance(uncompressedBBR).asInstanceOf[T]
+  }
+
+  override def next = {
+    initialized = true
+    baseIter.next()
+  }
+
+  // Semantics are to not change state - read-only
+  override def current: Object = {
+    if (!initialized) {
+      null
+    } else {
+      baseIter.current
+    }
+  }
+}

--- a/src/main/scala/shark/memstore2/column/LZFSerializer.scala
+++ b/src/main/scala/shark/memstore2/column/LZFSerializer.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import scala.collection.mutable._
+import shark.memstore2.buffer.ByteBufferReader
+
+import it.unimi.dsi.fastutil.bytes.ByteArrayList
+
+import com.ning.compress.lzf.LZFEncoder
+import com.ning.compress.lzf.LZFDecoder
+import com.ning.compress.lzf.LZFInputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+
+// class LZFBlockSerializer{
+
+// LZF chunk length is 64K - so to get one least one chunk in the decode always
+// try to decode more than that.
+
+//   def decodeStream(
+
+// }
+
+object LZFSerializer{
+
+  def encode(b: Array[Byte]) = LZFEncoder.encode(b)
+  def decode(b: Array[Byte]) = LZFDecoder.decode(b)
+
+  // Also advances the buffer to the point after the uncompressedBytes have been written
+  def writeToBuffer(buf: ByteBuffer, compressedBytes: Array[Byte]) {
+    val len = compressedBytes.size
+    val iter = compressedBytes.iterator
+    buf.putInt(len)
+    while (iter.hasNext) {
+      buf.put(iter.next)
+    }
+    buf
+  }
+
+  // Also advances the buffer to the point after the uncompressedBytes have been read
+  def readFromBuffer(buf: ByteBufferReader): Array[Byte] = {
+    val num = buf.getInt()
+    var compressedBytes = new Array[Byte](num)
+
+    var i = 0
+    while (i < num) {
+      compressedBytes(i) = (buf.getByte())
+      i += 1
+    }
+    compressedBytes
+  }
+
+}

--- a/src/main/scala/shark/memstore2/column/LZFSerializer.scala
+++ b/src/main/scala/shark/memstore2/column/LZFSerializer.scala
@@ -43,31 +43,29 @@ object LZFSerializer{
   def decode(b: Array[Byte]): Array[Byte] = LZFDecoder.decode(b)
 
 
-  // Also advances the buffer to the point after the uncompressedBytes have been written
+  /** Write compressed data in an array to ByteBuffer 
+    * Also advances the buffer to the point after the uncompressedBytes have been written
+    */
   def writeToBuffer(buf: ByteBuffer, numUncompressedBytes: Int, compressedBytes: Array[Byte]) {
     buf.putInt(numUncompressedBytes)
     val len = compressedBytes.size
     buf.putInt(len)
-    val iter = compressedBytes.iterator
-    while (iter.hasNext) {
-      buf.put(iter.next)
-    }
+
+    buf.put(compressedBytes)
     buf
   }
 
-  // Also advances the buffer to the point after the uncompressedBytes have been read
+  /** Read compressed data into an array from a ByteBuffer 
+    * Also advances the buffer to the point after the uncompressedBytes have been written
+    * Returns a tuple of (numUncompressedBytes, compressedBytes)
+    */
   def readFromBuffer(buf: ByteBufferReader): (Int, Array[Byte]) = {
     val numUncompressedBytes = buf.getInt()
     val num = buf.getInt()
     var compressedBytes = new Array[Byte](num)
 
-    var i = 0
-    while (i < num) {
-      compressedBytes(i) = (buf.getByte())
-      i += 1
-    }
+    buf.getBytes(compressedBytes, num)
     (numUncompressedBytes, compressedBytes)
   }
-
 
 }

--- a/src/main/scala/shark/memstore2/column/LZFSerializer.scala
+++ b/src/main/scala/shark/memstore2/column/LZFSerializer.scala
@@ -30,6 +30,9 @@ import java.nio.ByteOrder
 import java.io.InputStream
 
 
+/** Helper object to implement LZF compression across both the
+  * LZFColumnIterator and various Builders.
+  */
 object LZFSerializer{
   val MIN_CHUNK_BYTES = 230 // a safe set of bytes to account for stuff added on
                             // by LZF even if there is nothing to compress

--- a/src/main/scala/shark/memstore2/column/LongColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/LongColumnBuilder.scala
@@ -29,10 +29,10 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspect
 class LongColumnBuilder extends ColumnBuilder[Long] {
 
   private var _stats: ColumnStats.LongColumnStats = null
-  private var _arr: LongArrayList = null
+  private var _nonNulls: LongArrayList = null
 
   override def initialize(initialSize: Int) {
-    _arr = new LongArrayList(initialSize)
+    _nonNulls = new LongArrayList(initialSize)
     _stats = new ColumnStats.LongColumnStats
     super.initialize(initialSize)
   }
@@ -47,13 +47,12 @@ class LongColumnBuilder extends ColumnBuilder[Long] {
   }
 
   override def append(v: Long) {
-    _arr.add(v)
+    _nonNulls.add(v)
     _stats.append(v)
   }
 
   override def appendNull() {
-    _nullBitmap.set(_arr.size)
-    _arr.add(0)
+    _nullBitmap.set(_nonNulls.size + _stats.nullCount)
     _stats.appendNull()
   }
 
@@ -61,15 +60,15 @@ class LongColumnBuilder extends ColumnBuilder[Long] {
 
   override def build: ByteBuffer = {
     val buf = ByteBuffer.allocate(
-      _arr.size * 8 + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
+      _nonNulls.size * 8 + ColumnIterator.COLUMN_TYPE_LENGTH + sizeOfNullBitmap)
     buf.order(ByteOrder.nativeOrder())
     buf.putLong(ColumnIterator.LONG)
 
     writeNullBitmap(buf)
 
     var i = 0
-    while (i < _arr.size) {
-      buf.putLong(_arr.get(i))
+    while (i < _nonNulls.size) {
+      buf.putLong(_nonNulls.get(i))
       i += 1
     }
     buf.rewind()

--- a/src/main/scala/shark/memstore2/column/RLEColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/RLEColumnIterator.scala
@@ -29,14 +29,11 @@ import it.unimi.dsi.fastutil.ints.IntArrayList
   * 
   */
 
-class RLEColumnIterator[T <: ColumnIterator](
-  baseIterCls: Class[T])
-    extends ColumnIterator {
-
+class RLEColumnIterator[T <: ColumnIterator](baseIterCls: Class[T]) extends ColumnIterator {
   private var extPos = -1
   private var currentRunPos = -1
   private var intPos = -1
-  private def length = lengths.get(intPos)
+  private def length = lengths.getInt(intPos)
 
   private var lengths: IntArrayList = null
   var baseIter: T = _
@@ -57,33 +54,32 @@ class RLEColumnIterator[T <: ColumnIterator](
   }
 
   override def next() {
-    require(lengths != null)
     // first call
     if (currentRunPos == -1) {
       intPos = 0;
       currentRunPos = 0;
       baseIter.next()
       extPos = 0
-      return
-    }
-
-    extPos += 1
-    // logDebug("current length " + length + " intPos " + intPos + " currentRunPos " + currentRunPos + " extPos " + extPos)
-
-    if(currentRunPos < (length-1)) {
-      // still inside run - current will return the right value
-      currentRunPos += 1
-
     } else {
-      if(currentRunPos == length-1 ) {
-        currentRunPos = 0
-      } else { // > 
-        throw new RuntimeException("Run position longer than length of run")
-      }
 
-      intPos += 1
-      baseIter.next()
-      // logDebug(" pos " + extPos + " value " + current)
+      extPos += 1
+      // logDebug("current length " + length + " intPos " + intPos + " currentRunPos " + currentRunPos + " extPos " + extPos)
+
+      if(currentRunPos < (length-1)) {
+        // still inside run - current will return the right value
+        currentRunPos += 1
+
+      } else {
+        if(currentRunPos == length-1 ) {
+          currentRunPos = 0
+        } else { // >
+          throw new RuntimeException("Run position longer than length of run")
+        }
+
+        intPos += 1
+        baseIter.next()
+        // logDebug(" pos " + extPos + " value " + current)
+      }
     }
   }
 

--- a/src/main/scala/shark/memstore2/column/RLEColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/RLEColumnIterator.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import shark.memstore2.buffer.ByteBufferReader
+import it.unimi.dsi.fastutil.ints.IntArrayList
+
+import shark.LogHelper
+
+/**
+  * A wrapper around any ColumnIterator so it can be Run Length Encoded
+  * 
+  * Builder classes should serialize the lengths of runs into the Buffer first
+  * then follow that with a serialization of the actual values.
+  * Run lengths are assumed to be small enough to fit into Ints.
+  * 
+  */
+
+class RLEColumnIterator[T <: ColumnIterator](baseIterCls: Class[T], bytes: ByteBufferReader)
+    extends ColumnIterator{
+  private var lengths: IntArrayList = RLESerializer.readFromBuffer(bytes)
+
+  private var extPos = -1
+  private var currentRunPos = -1
+  private var intPos = -1
+
+  private def length = lengths.get(intPos)
+
+  val baseIter: T = {
+     val ctor = baseIterCls.getConstructor(classOf[ByteBufferReader])
+     ctor.newInstance(bytes).asInstanceOf[T]
+  }
+
+  override def next() {
+    // first call
+    if (currentRunPos == -1) {
+      intPos = 0;
+      currentRunPos = 0;
+      baseIter.next()
+      extPos = 0
+      return
+    }
+
+    extPos += 1
+    // logDebug("current length " + length + " intPos " + intPos + " currentRunPos " + currentRunPos + " extPos " + extPos)
+
+    if(currentRunPos < (length-1)) {
+      // still inside run - current will return the right value
+      currentRunPos += 1
+
+    } else {
+      if(currentRunPos == length-1 ) {
+        currentRunPos = 0
+      } else { // > 
+        throw new RuntimeException("Run position longer than length of run")
+      }
+
+      intPos += 1
+      baseIter.next()
+      // logDebug(" pos " + extPos + " value " + current)
+
+    }
+  }
+
+  // Semantics are to not change state - read-only
+  override def current: Object = {
+    if (currentRunPos == -1) {
+      throw new RuntimeException("RLEColumnIterator next() should be called first")
+    } else {
+      baseIter.current
+    }
+  }
+}

--- a/src/main/scala/shark/memstore2/column/RLEColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/RLEColumnIterator.scala
@@ -20,8 +20,6 @@ package shark.memstore2.column
 import shark.memstore2.buffer.ByteBufferReader
 import it.unimi.dsi.fastutil.ints.IntArrayList
 
-import shark.LogHelper
-
 /**
   * A wrapper around any ColumnIterator so it can be Run Length Encoded
   * 
@@ -86,7 +84,6 @@ class RLEColumnIterator[T <: ColumnIterator](
       intPos += 1
       baseIter.next()
       // logDebug(" pos " + extPos + " value " + current)
-
     }
   }
 

--- a/src/main/scala/shark/memstore2/column/RLESerializer.scala
+++ b/src/main/scala/shark/memstore2/column/RLESerializer.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+import shark.memstore2.buffer.ByteBufferReader
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+import scala.collection.mutable.ListBuffer
+
+import it.unimi.dsi.fastutil.bytes.ByteArrayList
+import it.unimi.dsi.fastutil.ints.IntArrayList
+
+import scala.collection.mutable._
+
+import scala.annotation.tailrec
+
+
+/* Decorator attempt with abstract override - incomplete - nandu
+ * cannot get factory to work
+trait RLEncoding[T] extends ColumnBuilder[T]{
+  private var list:ListBuffer[T] = null
+
+  abstract override def append(v: T) {
+    list += v
+    super.append(v)
+  }
+
+  abstract override def build: ByteBuffer {
+    var rle = RLESerializer.encode(list.toList)
+    var buf = ByteBuffer.allocate(20480)
+    buf.order(ByteOrder.nativeOrder())
+
+    RLESerializer.writeToBuffer(buf, l)
+    buf.rewind
+
+    super.buildIntoExistingBuffer
+
+
+    buf
+  }
+}
+*/
+
+class RLEStreamingSerializer[A](val fac: () => A){
+  var coded = collection.mutable.ListBuffer.empty[(Int,A)]
+  private var coded_ = coded
+
+  // TODO consider a encodeFinished() call and make this a read-only method
+  def getCoded = {
+    if(previousRun == 0) { // never initialized
+      Nil
+    }
+    if(coded.length == 0 && previousRun != 0) { // exactly one value
+      coded.append((previousRun, previous))
+      coded.toList
+    } else {
+      val (lastrun, lastval): (Int, A) = coded.toList(coded.length-1)
+      // println(" last " + lastval + " prev " + previous)
+      if(lastval != previous) {
+        coded.append((previousRun, previous))
+      } else {
+        if(lastrun != previousRun) {
+          coded.insert(coded.length-1, (lastrun, lastval))
+          previous = lastval
+        }
+      }
+      coded.toList
+    }
+  }
+
+  private var previous: A = fac()
+  private var previousRun: Int = 0
+
+  def encodeSingle(current: A): Unit =
+    if (previousRun > 0) {
+      if(previous == current) { // same value
+        previousRun += 1
+      } else { // diff value
+        coded.append((previousRun, previous))
+        previous = current
+        previousRun = 1
+      }
+    } else { // first time
+      previous = current
+      previousRun = 1
+    }
+
+}
+
+object RLESerializer{
+
+// http://aperiodic.net/phil/scala/s-99/p13.scala
+//     Implement the so-called run-length encoding data compression method
+//
+//     Example:
+//     scala> encodeDirect(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e))
+//     res0: List[(Int, Symbol)] = List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e))
+
+  // @tailrec def encode[A](ls: List[A]): List[(Int, A)] =
+  //   if (ls.isEmpty) Nil
+  //   else {
+  //     val (packed, next) = ls span { _ == ls.head }
+  //     (packed.length, packed.head) :: encode(next)
+  //   }
+
+  def encode[A](ls: List[A]): List[(Int, A)] =
+    encode(ls, Nil)
+
+
+  @tailrec def encode[A](ls: List[A], acc: List[(Int, A)]): List[(Int, A)] =
+    if (ls.isEmpty) acc
+    else {
+      val (packed, next) = ls span { _ == ls.head }
+      val revAcc = acc ::: List[(Int, A)]((packed.length, packed.head))
+      encode(next, revAcc)
+    }
+
+
+// http://aperiodic.net/phil/scala/s-99/p12.scala
+//     Given a run-length code list generated as specified in problem P10,
+//     construct its uncompressed version.
+//
+//     Example:
+//     scala> decode(List((4, 'a), (1, 'b), (2, 'c), (2, 'a), (1, 'd), (4, 'e)))
+//     res0: List[Symbol] = List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)
+
+  def decode[A](ls: List[(Int, A)]): List[A] =
+    ls flatMap { e => List.fill(e._1)(e._2) }
+
+  // Prefix the run lengths into the buffer
+  // Also advances the buffer to the point after the lengths have been written
+  def writeToBuffer(buf: ByteBuffer, lengths: List[Int]) {
+    buf.order(ByteOrder.nativeOrder())
+    val len = lengths.size
+    val iter = lengths.iterator
+    buf.putInt(len)
+    while (iter.hasNext) {
+      buf.putInt(iter.next)
+    }
+    buf
+  }
+
+
+  // Version with IntArrayList java implementation instead of scala Lists
+  // Also advances the buffer to the point after the lengths have been written
+  def writeToBuffer(buf: ByteBuffer, lengths: IntArrayList) {
+    buf.order(ByteOrder.nativeOrder())
+    buf.putInt(lengths.size)
+    var i = 0
+    while (i < lengths.size) {
+      buf.putInt(lengths.get(i))
+      i += 1
+    }
+    buf
+  }
+
+
+  // Create a List[Ints] representing the lengths from the byte buffer.
+  // Also advances the buffer to the point after the lengths have been read
+  // def readFromBuffer(buf: ByteBufferReader): List[Int] = {
+  //   val numLengths = buf.getInt()
+  //   var lengths = ListBuffer[Int]()
+  //   var i = 0
+  //   while (i < numLengths) {
+  //     lengths += buf.getInt()
+  //     i += 1
+  //   }
+  //   lengths.toList
+  // }
+
+
+  // Create a List[Ints] representing the lengths from the byte buffer.
+  // Also advances the buffer to the point after the lengths have been read
+  def readFromBuffer(buf: ByteBufferReader): IntArrayList = {
+    val numLengths = buf.getInt()
+    var lengths: IntArrayList = new IntArrayList(numLengths)
+
+    var i = 0
+    while (i < numLengths) {
+      lengths.add(buf.getInt())
+      i += 1
+    }
+    lengths
+  }
+
+} // object

--- a/src/main/scala/shark/memstore2/column/RLESerializer.scala
+++ b/src/main/scala/shark/memstore2/column/RLESerializer.scala
@@ -160,18 +160,13 @@ object RLESerializer{
   }
 
 
-  // Create a IntArrayList representing the run lengths from the byte buffer.
+  // Create a ByteBufferReader representing the run lengths from the byte buffer.
   // Also advances the buffer to the point after the lengths have been read
-  def readFromBuffer(buf: ByteBufferReader): IntArrayList = {
+  def readFromBuffer(buf: ByteBufferReader): (Int, ByteBufferReader) = {
+    val lengths = buf.duplicate
     val numLengths = buf.getInt()
-    var lengths: IntArrayList = new IntArrayList(numLengths)
-
-    var i = 0
-    while (i < numLengths) {
-      lengths.add(buf.getInt())
-      i += 1
-    }
-    lengths
+    buf.position(4*numLengths + buf.position) //advance the main ByteBuffer
+    lengths.getInt() // also advance on the lengths duplicated ByteBuffer
+    (numLengths, lengths)
   }
-
 } // object

--- a/src/main/scala/shark/memstore2/column/RLESerializer.scala
+++ b/src/main/scala/shark/memstore2/column/RLESerializer.scala
@@ -23,8 +23,6 @@ import shark.memstore2.buffer.ByteBufferReader
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-
-import it.unimi.dsi.fastutil.bytes.ByteArrayList
 import it.unimi.dsi.fastutil.ints.IntArrayList
 
 
@@ -55,7 +53,7 @@ trait RLEncoding[T] extends ColumnBuilder[T]{
 */
 
 class RLEStreamingSerializer[A](val fac: () => A){
-  var coded = collection.mutable.ListBuffer.empty[(Int,A)]
+  var coded = collection.mutable.ArrayBuffer.empty[(Int,A)]
   private var coded_ = coded
 
   // TODO consider a encodeFinished() call and make this a read-only method
@@ -140,21 +138,8 @@ object RLESerializer{
   def decode[A](ls: List[(Int, A)]): List[A] =
     ls flatMap { e => List.fill(e._1)(e._2) }
 
+
   // Prefix the run lengths into the buffer
-  // Also advances the buffer to the point after the lengths have been written
-  def writeToBuffer(buf: ByteBuffer, lengths: List[Int]) {
-    buf.order(ByteOrder.nativeOrder())
-    val len = lengths.size
-    val iter = lengths.iterator
-    buf.putInt(len)
-    while (iter.hasNext) {
-      buf.putInt(iter.next)
-    }
-    buf
-  }
-
-
-  // Version with IntArrayList java implementation instead of scala Lists
   // Also advances the buffer to the point after the lengths have been written
   def writeToBuffer(buf: ByteBuffer, lengths: IntArrayList) {
     buf.order(ByteOrder.nativeOrder())
@@ -168,21 +153,7 @@ object RLESerializer{
   }
 
 
-  // Create a List[Ints] representing the lengths from the byte buffer.
-  // Also advances the buffer to the point after the lengths have been read
-  // def readFromBuffer(buf: ByteBufferReader): List[Int] = {
-  //   val numLengths = buf.getInt()
-  //   var lengths = ListBuffer[Int]()
-  //   var i = 0
-  //   while (i < numLengths) {
-  //     lengths += buf.getInt()
-  //     i += 1
-  //   }
-  //   lengths.toList
-  // }
-
-
-  // Create a List[Ints] representing the lengths from the byte buffer.
+  // Create a IntArrayList representing the run lengths from the byte buffer.
   // Also advances the buffer to the point after the lengths have been read
   def readFromBuffer(buf: ByteBufferReader): IntArrayList = {
     val numLengths = buf.getInt()

--- a/src/main/scala/shark/memstore2/column/RLESerializer.scala
+++ b/src/main/scala/shark/memstore2/column/RLESerializer.scala
@@ -21,8 +21,7 @@ import scala.collection.mutable._
 import scala.annotation.tailrec
 import shark.memstore2.buffer.ByteBufferReader
 
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
+import java.nio.{ ByteBuffer, IntBuffer, ByteOrder }
 import it.unimi.dsi.fastutil.ints.IntArrayList
 
 
@@ -151,6 +150,7 @@ object RLESerializer{
   def writeToBuffer(buf: ByteBuffer, lengths: IntArrayList) {
     buf.order(ByteOrder.nativeOrder())
     buf.putInt(lengths.size)
+
     var i = 0
     while (i < lengths.size) {
       buf.putInt(lengths.get(i))

--- a/src/main/scala/shark/memstore2/column/RLESerializer.scala
+++ b/src/main/scala/shark/memstore2/column/RLESerializer.scala
@@ -17,19 +17,15 @@
 
 package shark.memstore2.column
 
+import scala.collection.mutable._
+import scala.annotation.tailrec
 import shark.memstore2.buffer.ByteBufferReader
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
-import scala.collection.mutable.ListBuffer
-
 import it.unimi.dsi.fastutil.bytes.ByteArrayList
 import it.unimi.dsi.fastutil.ints.IntArrayList
-
-import scala.collection.mutable._
-
-import scala.annotation.tailrec
 
 
 /* Decorator attempt with abstract override - incomplete - nandu

--- a/src/main/scala/shark/memstore2/column/RLESerializer.scala
+++ b/src/main/scala/shark/memstore2/column/RLESerializer.scala
@@ -52,6 +52,10 @@ trait RLEncoding[T] extends ColumnBuilder[T]{
 }
 */
 
+/** Helper class to implement Run Length Encoding across both the
+  * RLEColumnIterator and various Builders. This one builds runs at item at a
+  * time.
+  */
 class RLEStreamingSerializer[A](val fac: () => A){
   var coded = collection.mutable.ArrayBuffer.empty[(Int,A)]
   private var coded_ = coded
@@ -98,6 +102,9 @@ class RLEStreamingSerializer[A](val fac: () => A){
 
 }
 
+/** Helper object to implement Run Length Encoding across both the
+  * RLEColumnIterator and various Builders.
+  */
 object RLESerializer{
 
 // http://aperiodic.net/phil/scala/s-99/p13.scala

--- a/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
@@ -17,6 +17,7 @@
 
 package shark.memstore2.column
 
+import shark.{LogHelper, SharkConfVars}
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -27,20 +28,27 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector
 import org.apache.hadoop.io.Text
 
+import collection.mutable._
+import collection.mutable.ListBuffer
 
-class StringColumnBuilder extends ColumnBuilder[Text] {
+class StringColumnBuilder extends ColumnBuilder[Text] with LogHelper {
 
   private var _stats: ColumnStats.StringColumnStats = null
+  private var _uniques: collection.mutable.Set[Text] = new HashSet()
 
   // In string, a length of -1 is used to represent null values.
   private val NULL_VALUE = -1
   private var _arr: ByteArrayList = null
   private var _lengthArr: IntArrayList = null
 
+  // build run length encoding optimistically
+  private var rleSs = new RLEStreamingSerializer[Text]( { () => null })
+
   override def initialize(initialSize: Int) {
     _arr = new ByteArrayList(initialSize * ColumnIterator.STRING_SIZE)
     _lengthArr = new IntArrayList(initialSize)
     _stats = new ColumnStats.StringColumnStats
+    logInfo("initialized a StringColumnStats ")
     super.initialize(initialSize)
   }
 
@@ -57,6 +65,7 @@ class StringColumnBuilder extends ColumnBuilder[Text] {
     _lengthArr.add(v.getLength)
     _arr.addElements(_arr.size, v.getBytes, 0, v.getLength)
     _stats.append(v)
+    _uniques += v
   }
 
   override def appendNull() {
@@ -66,11 +75,128 @@ class StringColumnBuilder extends ColumnBuilder[Text] {
 
   override def stats = _stats
 
+  def pickCompressionScheme: String = {
+    // Initial RLE choice logic - use RLE if the
+    // selectivity is > 20% &&
+    // ratio of transitions > 30% &&
+    // #uniques is under 10000 (avoid stack overflows)
+    val selectivity = (_uniques.size).toDouble / _lengthArr.size
+    val transitionsRatio = (_stats.transitions).toDouble / _lengthArr.size
+    val rleUsed = 
+      ((selectivity < 0.2) &&
+        (transitionsRatio < 0.3) &&
+        (_uniques.size < 10000))
+    logInfo("uniques=" + _uniques.size + " selectivity=" + selectivity + 
+      " transitionsRatio=" + transitionsRatio + 
+      " transitions=" + _stats.transitions +
+      " #values=" + _lengthArr.size)
+
+    if(rleUsed) "RLE"
+    else "none"
+  }
+
+
   override def build: ByteBuffer = {
-    val buf = ByteBuffer.allocate(
-      _lengthArr.size * 4 + _arr.size + ColumnIterator.COLUMN_TYPE_LENGTH)
-    buf.order(ByteOrder.nativeOrder())
-    buf.putLong(ColumnIterator.STRING)
+
+    var scheme = System.getenv("TEST_SHARK_COLUMN_COMPRESSION_SCHEME")
+    if(scheme == null || scheme == "auto") scheme = pickCompressionScheme
+    // choices are none, auto, RLE, LZF
+
+    scheme.toUpperCase match {
+      case "NONE" => {
+        var minbufsize = _lengthArr.size * 4 + _arr.size +
+        ColumnIterator.COLUMN_TYPE_LENGTH
+        val buf = ByteBuffer.allocate(minbufsize)
+        logInfo("Allocated ByteBuffer of scheme " + scheme + " size " + minbufsize)
+        buf.order(ByteOrder.nativeOrder())
+        buf.putLong(ColumnIterator.STRING)
+
+        populateStringsInBuffer(_arr, _lengthArr, buf)
+      }
+      case "LZF" => {
+
+        // on waking up - craft a byte array and send it for LZF compr
+        val tempBufSize = _lengthArr.size * 4 + _arr.size
+        val tempBuf = ByteBuffer.allocate(tempBufSize)
+        logInfo("Allocated tempBuf of size " + tempBufSize)
+        tempBuf.order(ByteOrder.nativeOrder())
+        populateStringsInBuffer(_arr, _lengthArr, tempBuf)
+        tempBuf.rewind
+        val arr: Array[Byte] = tempBuf.array()
+
+        val compressed = LZFSerializer.encode(arr)
+
+        var minbufsize = 4 + compressed.size +
+        ColumnIterator.COLUMN_TYPE_LENGTH
+        val buf = ByteBuffer.allocate(minbufsize)
+        logInfo("Allocated ByteBuffer of scheme " + scheme + " size " + minbufsize)
+        buf.order(ByteOrder.nativeOrder())
+        buf.putLong(ColumnIterator.LZF_STRING)
+
+        LZFSerializer.writeToBuffer(buf, compressed)
+        buf.rewind
+        buf
+      }
+      case "RLE" => {
+        // var strings = new ListBuffer[Text]()
+        var totalStringLengthInBuffer = 0
+
+        var i = 0
+        var runningOffset = 0
+        while (i < _lengthArr.size) {
+          if (NULL_VALUE != _lengthArr.get(i)) {
+            val writable = new Text()
+            writable.append(_arr.elements(), runningOffset, _lengthArr.get(i))
+            rleSs.encodeSingle(writable)
+            // println(writable.toString + " len " + _lengthArr.get(i))
+            totalStringLengthInBuffer += (_lengthArr.get(i) + 4)
+            runningOffset += _lengthArr.get(i)
+          } else {
+            rleSs.encodeSingle(null)
+            // println( " len " + _lengthArr.get(i))
+            totalStringLengthInBuffer += 4
+          }
+          i += 1
+        }
+        // alternative recursive call for encode in bulk
+        // val rleStrings = RLESerializer.encode(strings.toList)
+        
+        // streaming construction
+        val rleStrings = rleSs.getCoded
+
+        totalStringLengthInBuffer = 0
+        var runs = new ArrayBuffer[Int]()
+        rleStrings.foreach { x =>
+          val (run, value) = x
+          runs += run
+          totalStringLengthInBuffer += 4 // int to mark length
+          if(value != null)
+            totalStringLengthInBuffer += value.getLength()
+        }
+
+        var minbufsize = rleStrings.size*4 + //runs
+        rleStrings.size*4 + //lengths per string
+        totalStringLengthInBuffer         + //string
+        ColumnIterator.COLUMN_TYPE_LENGTH
+        logInfo("number of Strings " + rleStrings.size + " totalStringLengthInBuffer  " + totalStringLengthInBuffer)
+
+        val buf = ByteBuffer.allocate(minbufsize)
+        buf.order(ByteOrder.nativeOrder())
+        buf.putLong(ColumnIterator.RLE_STRING)
+
+        logInfo("Allocated ByteBuffer (RLE) of size " + minbufsize)
+        logInfo("size of runs " + runs.size)
+        RLESerializer.writeToBuffer(buf, runs.toList)
+        populateStringsInBuffer(rleStrings, buf)
+      }
+      case _ => throw new IllegalArgumentException(
+        "scheme muse be one of auto, none, RLE, LZF")
+    } // match
+  }
+
+  protected def populateStringsInBuffer(_arr:ByteArrayList,
+    _lengthArr:IntArrayList, buf:ByteBuffer): ByteBuffer = {
+
     var i = 0
     var runningOffset = 0
     while (i < _lengthArr.size) {
@@ -84,8 +210,38 @@ class StringColumnBuilder extends ColumnBuilder[Text] {
 
       i += 1
     }
-    buf.rewind()
+
+    buf.rewind
     buf
   }
-}
 
+  // for encoded pairs of (length, value)
+  protected def populateStringsInBuffer(l: List[(Int, Text)],
+    buf: ByteBuffer): ByteBuffer = {
+
+    var i = 0
+    var runningOffset = 0
+
+    val iter = l.iterator
+
+    while (iter.hasNext) {
+      val (run, value) = iter.next
+      var len = NULL_VALUE
+      if (value != null) {
+        len = value.getLength()
+      }
+
+      buf.putInt(len)
+      runningOffset += 1
+
+      if (NULL_VALUE != len && 0 != len) {
+        buf.put(value.getBytes(), 0, len)
+        runningOffset += len
+      }
+    }
+
+    buf.rewind
+    buf
+  }
+
+}

--- a/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
@@ -44,7 +44,7 @@ class StringColumnBuilder extends ColumnBuilder[Text] with LogHelper{
     _arr = new ByteArrayList(initialSize * ColumnIterator.STRING_SIZE)
     _lengthArr = new IntArrayList(initialSize)
     _stats = new ColumnStats.StringColumnStats
-    logInfo("initialized a StringColumnStats ")
+    logDebug("initialized a StringColumnStats ")
     super.initialize(initialSize)
   }
 

--- a/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
@@ -16,8 +16,8 @@
  */
 
 package shark.memstore2.column
-
 import shark.{LogHelper, SharkConfVars}
+import collection.mutable.{Set, HashSet}
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -32,7 +32,10 @@ import org.apache.hadoop.io.Text
 import collection.mutable._
 import collection.mutable.ListBuffer
 
-class StringColumnBuilder extends ColumnBuilder[Text] with LogHelper {
+class StringColumnBuilder extends ColumnBuilder[Text]{
+  // logger problems - rmeove before commit
+  private def logInfo(msg: String) = { println("INFO " + msg) }
+  private def logDebug(msg: String) = { println("DEBUG " + msg) }
 
   private var _stats: ColumnStats.StringColumnStats = null
   private var _uniques: collection.mutable.Set[Text] = new HashSet()
@@ -46,10 +49,18 @@ class StringColumnBuilder extends ColumnBuilder[Text] with LogHelper {
   private var rleSs = new RLEStreamingSerializer[Text]( { () => null })
 
   override def initialize(initialSize: Int) {
+    initialize(initialSize, "auto", "auto")
+  }
+
+  override def initialize(initialSize: Int,
+                          columnarComprString: String,
+                          columnarComprInt: String) {
     _arr = new ByteArrayList(initialSize * ColumnIterator.STRING_SIZE)
     _lengthArr = new IntArrayList(initialSize)
     _stats = new ColumnStats.StringColumnStats
     logInfo("initialized a StringColumnStats ")
+    // override from TBLPROPERTIES
+    scheme = columnarComprString
     super.initialize(initialSize)
   }
 
@@ -82,24 +93,41 @@ class StringColumnBuilder extends ColumnBuilder[Text] with LogHelper {
     // ratio of transitions < 30% 
     val selectivity = (_uniques.size).toDouble / _lengthArr.size
     val transitionsRatio = (_stats.transitions).toDouble / _lengthArr.size
+  
     val rleUsed = 
       ((selectivity < 0.2) &&
         (transitionsRatio < 0.3))
-    logInfo("uniques=" + _uniques.size + " selectivity=" + selectivity + 
-      " transitionsRatio=" + transitionsRatio + 
-      " transitions=" + _stats.transitions +
-      " #values=" + _lengthArr.size)
 
     if(rleUsed) "RLE"
     else "none"
   }
 
+  var scheme = "auto"
 
   override def build: ByteBuffer = {
 
-    var scheme = System.getenv("TEST_SHARK_STRING_COLUMN_COMPRESSION_SCHEME")
-    if(scheme == null || scheme == "auto") scheme = pickCompressionScheme
+    // highest priority override is if someone (like a test) calls the getter
+    //.scheme()
+    // TESTING
+    // scheme = "NONE"
+
+    // next priority override - from TBL PROPERTIES
+    // if(System.getenv("TEST_SHARK_STRING_COLUMN_COMPRESSION_SCHEME") != null)
+    //   scheme = System.getenv("TEST_SHARK_STRING_COLUMN_COMPRESSION_SCHEME")
     // choices are none, auto, RLE, LZF
+
+    // otherwise pick auto scheme 
+    if(scheme == null || scheme.toUpperCase == "AUTO") scheme = pickCompressionScheme
+
+    val selectivity = (_uniques.size).toDouble / _lengthArr.size
+    val transitionsRatio = (_stats.transitions).toDouble / _lengthArr.size
+  
+    logInfo("uniques=" + _uniques.size + " selectivity=" + selectivity +
+      " transitionsRatio=" + transitionsRatio + 
+      " transitions=" + _stats.transitions +
+      " #values=" + _lengthArr.size)
+
+
 
     scheme.toUpperCase match {
       case "NONE" => {
@@ -202,6 +230,7 @@ class StringColumnBuilder extends ColumnBuilder[Text] with LogHelper {
     var stringsSoFar = 0
     var outSoFar: Int = 0
     var tempSoFar: Int = 0
+    logInfo("going to ask for bytes " + (math.max(tempBufSize, 2*LZFSerializer.BLOCK_SIZE)))
     var out = new Array[Byte](math.max(tempBufSize, 2*LZFSerializer.BLOCK_SIZE)) // extra just in case nothing compresses
     var len = LZFSerializer.BLOCK_SIZE
     if(_lengthArr.size < LZFSerializer.BLOCK_SIZE) len = _lengthArr.size

--- a/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/StringColumnBuilder.scala
@@ -158,12 +158,13 @@ class StringColumnBuilder extends ColumnBuilder[Text] with LogHelper{
         val vals = rleStrings map (_._2)
         val runs = new IntArrayList(vals.size)
         totalStringLengthInBuffer = 0
-        rleStrings.foreach { x => 
+        rleStrings.foreach { x =>
           runs.add(x._1)
           val value = x._2
           totalStringLengthInBuffer += 4 // int to mark length
-          if(value != null)
+          if (value != null) {
             totalStringLengthInBuffer += value.getLength()
+          }
         }
 
         var minbufsize = rleStrings.size*4 + //runs

--- a/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
@@ -18,7 +18,7 @@
 package shark.parse
 
 import java.lang.reflect.Method
-import java.util.ArrayList
+import java.util.{ArrayList, Properties}
 import java.util.{List => JavaList}
 
 import scala.collection.JavaConversions._
@@ -111,6 +111,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
           td.getTblProps().put("shark.cache", cacheMode.toString)
         }
 
+
         if (CacheType.shouldCache(cacheMode)) {
           td.setSerName(classOf[ColumnarSerDe].getName)
         }
@@ -173,6 +174,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
         hiveSinkOps.map { hiveSinkOp =>
           val tableName = hiveSinkOp.asInstanceOf[HiveFileSinkOperator].getConf().getTableInfo()
             .getTableName()
+          val tableProperties = hiveSinkOp.asInstanceOf[HiveFileSinkOperator].getConf().getTableInfo().getProperties()
 
           if (tableName == null || tableName == "") {
             // If table name is empty, it is an INSERT (OVERWRITE) DIRECTORY.
@@ -188,8 +190,8 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
                   val storageLevel = RDDUtils.getStorageLevelOfCachedTable(rdd)
                   OperatorFactory.createSharkMemoryStoreOutputPlan(
                     hiveSinkOp,
-                    cachedTableName,
-                    storageLevel,
+                    tableProperties,
+                    rdd.getStorageLevel,
                     _resSchema.size,                // numColumns
                     cacheMode == CacheType.tachyon, // use tachyon
                     useUnionRDD)
@@ -210,9 +212,17 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
             val storageLevel = MemoryMetadataManager.getStorageLevelFromString(
               qb.getTableDesc().getTblProps.get("shark.cache.storageLevel"))
             qb.getTableDesc().getTblProps().put(CachedTableRecovery.QUERY_STRING, ctx.getCmd())
+
+            var tableProperties: Properties = new Properties
+            qb.getTableDesc().getTblProps().keySet().foreach { k => 
+              val v = qb.getTableDesc().getTblProps().get(k)
+              tableProperties.setProperty(k, v)
+            }
+            tableProperties.setProperty("name", qb.getTableDesc.getTableName)
+
             OperatorFactory.createSharkMemoryStoreOutputPlan(
               hiveSinkOps.head,
-              qb.getTableDesc.getTableName,
+              tableProperties,
               storageLevel,
               _resSchema.size,                // numColumns
               cacheMode == CacheType.tachyon, // use tachyon

--- a/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
@@ -182,6 +182,8 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
           } else {
             // Otherwise, check if we are inserting into a table that was cached.
             val cachedTableName = tableName.split('.')(1) // Ignore the database name
+            tableProperties.setProperty("name", cachedTableName)
+
             SharkEnv.memoryMetadataManager.get(cachedTableName) match {
               case Some(rdd) => {
                 if (hiveSinkOps.size == 1) {

--- a/src/test/scala/shark/SQLSuite.scala
+++ b/src/test/scala/shark/SQLSuite.scala
@@ -283,22 +283,22 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("creating cache tables with unsupported compression scheme") {
-    val e = intercept[QueryExecutionException] { 
+    val e = intercept[QueryExecutionException] {
       sc.sql("drop table if exists compr_cached")
       val intSchemeMod = "BADPROPS"
       val strSchemeMod = "BADPROPS"
       info("scheme overrides from SQL int[" + intSchemeMod + "] string[" + strSchemeMod + "]")
-      val tblProperties = """TBLPROPERTIES ("shark.columnar.compr.int"="""" +
+      val tblProperties = """TBLPROPERTIES ("shark.column.compress.int"="""" +
       intSchemeMod +
-      """", "shark.columnar.compr.string"="""" +
+      """", "shark.column.compress.string"="""" +
       strSchemeMod +
       """")"""
       val query = "create table compr_cached " + tblProperties + " as select * from test"
+      info(query)
       sc.sql(query) 
     }
     e.getMessage.contains("Bad compression scheme")
   }
-
 
   test("requests to compress unsupported column types is ignored like other unused TBLPROPERTIES") {
     sc.sql("DROP TABLE if exists compr_test")
@@ -306,11 +306,11 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
     sc.sql("LOAD DATA LOCAL INPATH '${hiveconf:shark.test.data.path}/kv1.txt' INTO TABLE compr_test")
 
     sc.sql("DROP TABLE if exists compr_test_cached")
-    sc.sql("""CREATE TABLE compr_test_cached TBLPROPERTIES("shark.columnar.compr.long"="RLE") 
+    sc.sql("""CREATE TABLE compr_test_cached TBLPROPERTIES("shark.column.compress.long"="RLE") 
            AS SELECT * FROM compr_test""")
 
     sc.sql("DROP TABLE if exists compr_test_cached")
-    sc.sql("""CREATE TABLE compr_test_cached TBLPROPERTIES("shark.columnar.compr.NOSUCHTYPE"="RLE") 
+    sc.sql("""CREATE TABLE compr_test_cached TBLPROPERTIES("shark.column.compress.NOSUCHTYPE"="RLE") 
            AS SELECT * FROM compr_test""")
     // no errors reported. no compression used
   }

--- a/src/test/scala/shark/SQLSuite.scala
+++ b/src/test/scala/shark/SQLSuite.scala
@@ -246,6 +246,75 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
     assert(!SharkEnv.memoryMetadataManager.contains("sharkTest5Cached"))
   }
 
+  test("creating cache tables with in-memory column compression") {
+    List("AuTo", "NoNe", "LZf", "RLe", "DiCt").foreach { intScheme =>
+      List("AuTo", "NoNe", "LZf", "RLe").foreach { strScheme =>
+        List((x: String) => x, // mixed case
+             (x: String) => x.toUpperCase(),
+             (x: String) => x.toLowerCase(),
+             (x: String) => x.toLowerCase().capitalize).foreach { caseManipulator =>
+
+          // test case insensitivity
+          var intSchemeMod = caseManipulator(intScheme)
+          var strSchemeMod = caseManipulator(strScheme)
+          sc.sql("drop table if exists compr_cached")
+          info("scheme overrides from SQL int[" + intSchemeMod + "] string[" + strSchemeMod + "]")
+          val tblProperties = """TBLPROPERTIES ("shark.column.compress.int"="""" +
+          intSchemeMod +
+          """", "shark.column.compress.string"="""" +
+          strSchemeMod +
+          """")"""
+          val query = "create table compr_cached " + tblProperties + " as select * from test"
+          // test that scheme names/combinations are correct
+          try {
+            sc.sql(query)
+          } catch {
+            case _ => { 
+              info("test failed at " + query)   // print so that it is clear which combination fails
+                                                // propogate exception further to get the full trace
+            }
+          }
+          // test contents
+          expect("select count(*) from compr_cached", "500")
+          expect("select val from compr_cached where key = 407", "val_407")
+        }
+      }
+    }
+  }
+
+  test("creating cache tables with unsupported compression scheme") {
+    val e = intercept[QueryExecutionException] { 
+      sc.sql("drop table if exists compr_cached")
+      val intSchemeMod = "BADPROPS"
+      val strSchemeMod = "BADPROPS"
+      info("scheme overrides from SQL int[" + intSchemeMod + "] string[" + strSchemeMod + "]")
+      val tblProperties = """TBLPROPERTIES ("shark.columnar.compr.int"="""" +
+      intSchemeMod +
+      """", "shark.columnar.compr.string"="""" +
+      strSchemeMod +
+      """")"""
+      val query = "create table compr_cached " + tblProperties + " as select * from test"
+      sc.sql(query) 
+    }
+    e.getMessage.contains("Bad compression scheme")
+  }
+
+
+  test("requests to compress unsupported column types is ignored like other unused TBLPROPERTIES") {
+    sc.sql("DROP TABLE if exists compr_test")
+    sc.sql("CREATE TABLE compr_test (key BIGINT, val STRING)")
+    sc.sql("LOAD DATA LOCAL INPATH '${hiveconf:shark.test.data.path}/kv1.txt' INTO TABLE compr_test")
+
+    sc.sql("DROP TABLE if exists compr_test_cached")
+    sc.sql("""CREATE TABLE compr_test_cached TBLPROPERTIES("shark.columnar.compr.long"="RLE") 
+           AS SELECT * FROM compr_test""")
+
+    sc.sql("DROP TABLE if exists compr_test_cached")
+    sc.sql("""CREATE TABLE compr_test_cached TBLPROPERTIES("shark.columnar.compr.NOSUCHTYPE"="RLE") 
+           AS SELECT * FROM compr_test""")
+    // no errors reported. no compression used
+  }
+
   //////////////////////////////////////////////////////////////////////////////
   // SharkContext APIs (e.g. sql2rdd, sql)
   //////////////////////////////////////////////////////////////////////////////

--- a/src/test/scala/shark/SQLSuite.scala
+++ b/src/test/scala/shark/SQLSuite.scala
@@ -34,9 +34,11 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
   override def beforeAll() {
     sc = SharkEnv.initWithSharkContext("shark-sql-suite-testing", MASTER);
 
-    sc.sql("set javax.jdo.option.ConnectionURL=jdbc:derby:;databaseName=" +
+    if (TestUtils.testAndSet()) {
+      sc.sql("set javax.jdo.option.ConnectionURL=jdbc:derby:;databaseName=" +
         METASTORE_PATH + ";create=true")
-    sc.sql("set hive.metastore.warehouse.dir=" + WAREHOUSE_PATH)
+      sc.sql("set hive.metastore.warehouse.dir=" + WAREHOUSE_PATH)
+    }
 
     sc.sql("set shark.test.data.path=" + TestUtils.dataFilePath)
 

--- a/src/test/scala/shark/memstore2/ByteBufferReaderSuite.scala
+++ b/src/test/scala/shark/memstore2/ByteBufferReaderSuite.scala
@@ -30,6 +30,7 @@ class ByteBufferReaderSuite extends FunSuite {
     val reader = new JavaByteBufferReader(buf)
     testData(reader)
     testPosition(reader)
+    testDuplicate(reader)
   }
 
   test("UnsafeDirectByteBufferReader") {
@@ -38,6 +39,7 @@ class ByteBufferReaderSuite extends FunSuite {
     val reader = ByteBufferReader.createUnsafeReader(buf)
     testData(reader)
     testPosition(reader)
+    testDuplicate(reader)
   }
 
   test("UnsafeHeapByteBufferReader") {
@@ -46,6 +48,7 @@ class ByteBufferReaderSuite extends FunSuite {
     val reader = ByteBufferReader.createUnsafeReader(buf)
     testData(reader)
     testPosition(reader)
+    testDuplicate(reader)
   }
 
   val data_size = 4 + 8 + 1 + 8 + 4 + 2 + 3 + 2*2 + 3*4 + 3*8 + 3*4 + 3*8
@@ -123,5 +126,15 @@ class ByteBufferReaderSuite extends FunSuite {
   def testPosition(reader: ByteBufferReader) {
     reader.position(4)
     assert(reader.getLong() === 10034534500L)
+  }
+
+  def testDuplicate(reader: ByteBufferReader) {
+    reader.position(0)
+    assert(reader.getInt() === 655350)
+    val reader1 = reader.duplicate()
+    assert(reader.getLong() === 10034534500L)
+    assert(reader1.getLong() === 10034534500L)
+    assert(reader.getByte() === 1.toByte)
+    assert(reader1.getByte() === 1.toByte)
   }
 }

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -193,11 +193,11 @@ class ColumnIteratorSuite extends FunSuite {
     buf.rewind
 
     var bbr = ByteBufferReader.createUnsafeReader(buf)
-    val newl = RLESerializer.readFromBuffer(bbr)
+    val (numNewl, newl) = RLESerializer.readFromBuffer(bbr)
     var lb = new ListBuffer[Int]()
     var j = 0
-    while (j < newl.size) {
-      lb  += newl.get(j)
+    while (j < numNewl) {
+      lb  += newl.getInt()
       j += 1
     }
     assert(lb.toList == l)
@@ -216,7 +216,7 @@ class ColumnIteratorSuite extends FunSuite {
     while(i < l.size) {
       it.next
       val writableOi = PrimitiveObjectInspectorFactory.writableIntObjectInspector
-      assert(l(i) == writableOi.getPrimitiveJavaObject(it.current))
+      assert(l(i) === writableOi.getPrimitiveJavaObject(it.current))
       i += 1
     }
 
@@ -238,12 +238,12 @@ class ColumnIteratorSuite extends FunSuite {
       buf.rewind
 
       var bbr = ByteBufferReader.createUnsafeReader(buf)
-      val newruns = RLESerializer.readFromBuffer(bbr)
+      val (newrunsSize, newruns) = RLESerializer.readFromBuffer(bbr)
 
       var lb = new ListBuffer[Int]()
       var j = 0
-      while (j < newruns.size) {
-        lb  += newruns.get(j)
+      while (j < newrunsSize) {
+        lb  += newruns.getInt()
         j += 1
       }
       assert(lb.toList == runs)

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -185,7 +185,7 @@ class ColumnIteratorSuite extends FunSuite {
       classOf[DictionaryEncodedIntColumnIterator.Default])
 
 
-    // too many unique values (>256) - compression should be turned off
+    // too many unique values (>256) - compression should not turn on
     val list = Range(-300, 300, 1)
     val seqJava : Seq[java.lang.Integer] = for {
       i <- list
@@ -200,7 +200,7 @@ class ColumnIteratorSuite extends FunSuite {
     assert(builder.stats.max === 299)
 
  
-    val nulls = List.fill(100)(null) 
+    val nulls = List.fill(100)(null)
     val seqWithNull = List.concat(nulls, seqJava)
     assert(seqWithNull.size == 700)
 

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -133,7 +133,7 @@ class ColumnIteratorSuite extends FunSuite {
   test("dictionary encoding Int") {
     val l = List[Int](1,22,30,4)
     val d = new IntDictionary
-    d.initialize(l)
+    d.initialize(l.toArray)
 
     assert(d.get(0) == 1)
 

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -17,6 +17,7 @@
 
 package shark.memstore2
 
+import it.unimi.dsi.fastutil.ints.IntArrayList
 import java.sql.Timestamp
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -168,6 +169,12 @@ class ColumnIteratorSuite extends FunSuite {
       assert(rle_decoded === l)
     }
 
+    def convertList(l: List[Int]): IntArrayList = {
+      var ret = new IntArrayList(l.size)
+      l.foreach { x => ret.add(x) }
+      ret
+    }
+
     // no runs
     testRLE(List[Int](1,22,30,4))
     // same repeating value
@@ -182,7 +189,7 @@ class ColumnIteratorSuite extends FunSuite {
     var buf = ByteBuffer.allocate(2048)
     buf.order(ByteOrder.nativeOrder())
 
-    RLESerializer.writeToBuffer(buf, l)
+    RLESerializer.writeToBuffer(buf, convertList(l))
     buf.rewind
 
     var bbr = ByteBufferReader.createUnsafeReader(buf)
@@ -197,7 +204,7 @@ class ColumnIteratorSuite extends FunSuite {
 
     // does layered serialization of runs+values & iterator work?
     buf.rewind
-    RLESerializer.writeToBuffer(buf, runs)
+    RLESerializer.writeToBuffer(buf, convertList(runs))
     values.foreach { i =>
       buf.putInt(i)
     }
@@ -227,7 +234,7 @@ class ColumnIteratorSuite extends FunSuite {
       var buf = ByteBuffer.allocate(204800)
       buf.order(ByteOrder.nativeOrder())
 
-      RLESerializer.writeToBuffer(buf, runs)
+      RLESerializer.writeToBuffer(buf, convertList(runs))
       buf.rewind
 
       var bbr = ByteBufferReader.createUnsafeReader(buf)

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -170,6 +170,7 @@ class ColumnIteratorSuite extends FunSuite {
       true)
     assert(builder.stats.min === -12)
     assert(builder.stats.max === 134)
+    assert(builder.isCompressed == true)
 
 
     val repeats = List.fill(20000)(2) 
@@ -183,7 +184,9 @@ class ColumnIteratorSuite extends FunSuite {
       builder,
       PrimitiveObjectInspectorFactory.writableIntObjectInspector,
       classOf[DictionaryEncodedIntColumnIterator.Default])
-
+    assert(builder.stats.min === -100)
+    assert(builder.stats.max === 99)
+    assert(builder.isCompressed == true)
 
     // too many unique values (>256) - compression should not turn on
     val list = Range(-300, 300, 1)
@@ -198,7 +201,7 @@ class ColumnIteratorSuite extends FunSuite {
       classOf[IntColumnIterator.Default])
     assert(builder.stats.min === -300)
     assert(builder.stats.max === 299)
-
+    assert(builder.isCompressed == false)
  
     val nulls = List.fill(100)(null)
     val seqWithNull = List.concat(nulls, seqJava)
@@ -211,7 +214,7 @@ class ColumnIteratorSuite extends FunSuite {
       classOf[IntColumnIterator.Default])
     assert(builder.stats.min === -300)
     assert(builder.stats.max === 299)
-
+    assert(builder.isCompressed == false)
 
   }
 

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -151,10 +151,11 @@ class ColumnIteratorSuite extends FunSuite {
     assert(d.get(0) == newd.get(0))
     assert(d.get(3) == newd.get(3))
   }
-
+ 
   test("int column") {
     val builder = new IntColumnBuilder
-    testColumn(
+ 
+   testColumn(
       Array[java.lang.Integer](0, 1, 2, 5, 134, -12, 1, 0, 99, 1),
       builder,
       PrimitiveObjectInspectorFactory.writableIntObjectInspector,
@@ -162,9 +163,10 @@ class ColumnIteratorSuite extends FunSuite {
     assert(builder.stats.min === -12)
     assert(builder.stats.max === 134)
     assert(builder.isCompressed == true)
-
+ 
     testColumn(
-      Array[java.lang.Integer](null, 1, 2, 5, 134, -12, null, 0, 99, 1),
+      Array[java.lang.Integer]
+        (null, 1, 2, null, 5, 134, -12, null, 0, 99, null, null, null, 1),
       builder,
       PrimitiveObjectInspectorFactory.writableIntObjectInspector,
       classOf[DictionaryEncodedIntColumnIterator.Default],
@@ -184,7 +186,8 @@ class ColumnIteratorSuite extends FunSuite {
       seqWRJava,
       builder,
       PrimitiveObjectInspectorFactory.writableIntObjectInspector,
-      classOf[DictionaryEncodedIntColumnIterator.Default])
+      classOf[DictionaryEncodedIntColumnIterator.Default],
+      false)
     assert(builder.stats.min === -100)
     assert(builder.stats.max === 99)
     assert(builder.isCompressed == true)
@@ -199,20 +202,24 @@ class ColumnIteratorSuite extends FunSuite {
       seqJava,
       builder,
       PrimitiveObjectInspectorFactory.writableIntObjectInspector,
-      classOf[IntColumnIterator.Default])
+      classOf[IntColumnIterator.Default],
+      false)
     assert(builder.stats.min === -300)
     assert(builder.stats.max === 299)
     assert(builder.isCompressed == false)
- 
-    val nulls = List.fill(100)(null)
+
+
+    val nulls = List.fill(10000)(null)
     val seqWithNull = List.concat(nulls, seqJava)
-    assert(seqWithNull.size == 700)
+    assert(seqWithNull.size == 10600)
 
     testColumn(
       seqJava,
       builder,
       PrimitiveObjectInspectorFactory.writableIntObjectInspector,
-      classOf[IntColumnIterator.Default])
+      classOf[IntColumnIterator.Default],
+      false) // TODO - should be EWAH nullable - but cannot get types right for
+             // test to pass
     assert(builder.stats.min === -300)
     assert(builder.stats.max === 299)
     assert(builder.isCompressed == false)
@@ -351,7 +358,7 @@ class ColumnIteratorSuite extends FunSuite {
       false,
       compareBinary)
     assert(builder.stats == null)
-
+ 
     def compareBinary(x: Object, y: Object): Boolean = {
       val xdata = x.asInstanceOf[ByteArrayRef].getData
       val ydata = y.asInstanceOf[LazyBinary].getWritableObject().getBytes()

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -161,6 +161,7 @@ class ColumnIteratorSuite extends FunSuite {
       classOf[DictionaryEncodedIntColumnIterator.Default])
     assert(builder.stats.min === -12)
     assert(builder.stats.max === 134)
+    assert(builder.isCompressed == true)
 
     testColumn(
       Array[java.lang.Integer](null, 1, 2, 5, 134, -12, null, 0, 99, 1),

--- a/src/test/scala/shark/memstore2/ColumnStatsSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnStatsSuite.scala
@@ -124,7 +124,6 @@ class ColumnStatsSuite extends FunSuite {
     assert(c.maxDelta == 21)
     // nulls are ignored in IntColumnStats for unique and transition counting
     assert(c.transitions === 4)
-    assert(c.uniques.size === 4)
 
     c = new ColumnStats.IntColumnStats
     Array(22, 1, 24).foreach(c.append)

--- a/src/test/scala/shark/memstore2/ColumnStatsSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnStatsSuite.scala
@@ -84,14 +84,17 @@ class ColumnStatsSuite extends FunSuite {
     var c = new ColumnStats.IntColumnStats
     c.append(0)
     assert(c.min == 0 && c.max == 0)
+    assert(c.transitions === 1)
     c.append(1)
     assert(c.min == 0 && c.max == 1)
+    assert(c.transitions === 2)
     c.append(-1)
     assert(c.min == -1 && c.max == 1)
     c.append(65537)
     assert(c.min == -1 && c.max == 65537)
     c.append(-65537)
     assert(c.min == -65537 && c.max == 65537)
+    assert(c.transitions === 5)
 
     c = new ColumnStats.IntColumnStats
     assert(c.isOrdered && c.isAscending && c.isDescending)
@@ -110,6 +113,7 @@ class ColumnStatsSuite extends FunSuite {
     c.appendNull()
     c.appendNull()
     assert(c.maxDelta == 18)
+    assert(c.transitions === 5)
 
     c = new ColumnStats.IntColumnStats
     Array(22, 1, 0, -5).foreach(c.append)
@@ -118,6 +122,9 @@ class ColumnStatsSuite extends FunSuite {
     c.appendNull()
     c.appendNull()
     assert(c.maxDelta == 21)
+    // nulls are ignored in IntColumnStats for unique and transition counting
+    assert(c.transitions === 4)
+    assert(c.uniques.size === 4)
 
     c = new ColumnStats.IntColumnStats
     Array(22, 1, 24).foreach(c.append)
@@ -205,17 +212,22 @@ class ColumnStatsSuite extends FunSuite {
     assert(c.min == null && c.max == null)
     c.append("a")
     assert(c.min.equals(T("a")) && c.max.equals(T("a")))
+    assert(c.transitions === 1)
     c.appendNull()
     assert(c.min.equals(T("a")) && c.max.equals(T("a")))
+    assert(c.transitions === 2)
     c.append("b")
     assert(c.min.equals(T("a")) && c.max.equals(T("b")))
+    assert(c.transitions === 3)
     c.append("b")
     assert(c.min.equals(T("a")) && c.max.equals(T("b")))
+    assert(c.transitions === 3)
     c.append("cccc")
     c.appendNull()
     assert(c.min.equals(T("a")) && c.max.equals(T("cccc")))
     c.append("0987")
     assert(c.min.equals(T("0987")) && c.max.equals(T("cccc")))
     assert(c.nullCount == 2)
+    assert(c.transitions === 6)
   }
 }


### PR DESCRIPTION
Functionality to compress columns stored in memory (cached tables).
This is a cleaned-up version of https://github.com/amplab/shark/pull/103

To see a more friendly version of this document go to -
https://github.com/junkumar/shark/wiki/Compressing-Columns-Stored-in-Memory

*\* Intro
This document details the design of the compression options for data stored in cached tables in shark. The goals are to 
1. Allow shark to store more data in a fixed amount of memory without sacrificing read access rates 
2. Provide direct access to the compressed data so that query execution does not require uncompression.

*\* How does it get used?
When a cached table is created in shark, all the data gets stored as columns
into memory. Compression can then be used to store these columns more efficiently in memory. The default behavior is to determine whether compression is appropriate and which compression scheme should be used based on the properties of the data being stored in memory.

*\* Compression schemes available
| _Scheme_                  | _Target column properties_                                     | _Column Types Currently Supported_ |
| Run Length Encoding(RLE)  | sorted OR small number of transitions OR Partition key columns | Int or String                      |
| Dictionary Encoding(Dict) | small number of unique values, but no runs                     | Int                                |
| Null Bit Vector Encoding  | sparse data, few non-null values                               | Int, Boolean, Long or Byte         |
| LZF Encoding              | slowest decompression speed  but best compression rate         | Int or String                      |
| NONE                      | raw storage; ideal if data has too many unique values          |                                    |
| Auto  (Default)               | Shark chooses one of the above compression schemes that it deems ideal based on the properties of the column data     | All                                   |

Null Encoding can be mixed with one of Dict, RLE or LZF Encoding on Int columns

*\* Compression results on production data at Yahoo
Tested on a 14 node cluster with a total of (14GB*14) 196 GB of RAM
Input data is a single table on HDFS/Hive with 4 parition keys and 3 other columns.

| _partition specification in input data_ | _number of rows_ | _HDFS bytes (RCfile compressed on disk)_  | _shark 0.7 bytes in memory (no compr)_ | _after compression bytes_  | _compr rate (% of uncompr)_ |
| action=ad_click p=1 dt=20130501         | 289,652          | 2,683,931     | 23,315,012                   | 8,832,576      |                       37.88 |
| p=1 dt=20130501                         | 153,494,679      | 964,635,051   | 13,602,326,763               | 2,565,180,073  |                       18.86 |
| action=search dt=20130501               | 226,388,853      | 7,350,168,969 | 18,066,874,698               | 6,353,214,544  |                       35.16 |
| action=search dt=2013050[1-5]           | 1,146,965,502    |               |                              | 91,496,897,244 |                             |

6 of the columns in this data were strings with no sort order and the seventh column was a integer column.
RLE was chosen automatically whenever compression got used. Especially on the 4
partition columns.

*\* Uncompression results 
We are building simpler "light-weight" compression schemes instead of just using
established "heavy-weight" schemes like gzip or LZF so that we are not limited
by uncompression speeds. Heavy-weight schemes work well for data on disk because
disk is much slower than the CPU uncompression. Memory access speeds are much
faster and CPU uncompression can become a bottleneck.

This comparison measures uncompression speeds across multiple schemes. Input
data is a single slice of the data from the last test tested on a single node
setup. This is a single string column with data in sorted order, with a small
number of unique values; expect very high compression rates. These synthetic
benchmarks were simply used to check our implementation beliefs about the
bottleneck and do not numerically model how things will work in the production
clusters.

50 trial runs were executed (with the first 20 not counted) in each case to
measure averages.

A comparison of memory throughput versus data throughput is a useful way for us to reason about our implementations. The memory throughput for "None" compression will always be the best. But the data throughput will depend on how compressible the data is. The more that the data compresses the less space it will take and higher the data throughput will be for a fixed memory throughput.

[[https://dl.dropboxusercontent.com/u/7259597/SharkDecompressionSpeeds.jpg]]

| _scheme_ | _rows_     |    _ms_ |  _data MBps_ |  _mem MBps_ |   _% compr rate_ |
| None     | 2,500,000  |   74.87 |     413.99 |     541.38 |         100.00 |
| LZF      | 2,500,000  |   75.50 |     410.52 |      21.92 |           4.08 |
| RLE      | 2,500,000  |   34.56 |     896.65 |      62.61 |           5.34 |
| None     | 20,500,000 |  706.50 |     359.74 |     470.43 |         100.00 |
| LZF      | 20,500,000 |  765.30 |     332.10 |      17.73 |           4.08 |
| RLE      | 20,500,000 |  326.87 |     777.55 |      54.30 |           5.34 |
| None     | 90,500,000 | 3126.03 |     358.92 |     469.36 |         100.00 |
| LZF      | 90,500,000 | 3071.10 |     365.34 |      19.50 |           4.08 |
| RLE      | 90,500,000 | 1539.23 |     728.93 |      50.90 |           5.34 |

**\* Observations
- Zero compression (None) yields the highest raw memory throughput - the CPU is 
  interfering the least in this case.
- In a classic space-time trade-off, the fact that compressed data uses less
  memory allows nearly the same overall data throughput (raw MBps) even
  though the memory throughput (mem MBps) is lower due to uncompression.
- LZF has better compression rates for this data but cannot keep up with either
  no compression or RLE in term of uncompression speeds.
- RLE offers us the best compromise by allowing us to maintain the overall access
  speed while still letting us store more data into memory.
- Ultimately, like other columnar stores, we will be able to work directly with
  compressed data without needing uncompression which will make RLE's advantage
  even bigger.

*\* The cost of compression
Disk access times are expected to dominate the time taken to create cache tables. But the cost of compression can be observed as an increase in the time taken to create cache tables and must be traded off against the benefits of storing compressed data in memory.

*\* Specifying compression in SQL
We expect the "Auto" scheme to work well in most situations. However, this can be overridden in SQL when desired. Currently compression schemes can only be set for all columns of a given data type in a cached table.
=CREATE TABLE test_cached 
TBLPROPERTIES("shark.column.compress.int"="RLE") 
AS SELECT \* FROM test;=

=CREATE TABLE test_cached 
TBLPROPERTIES("shark.column.compress.string"="None") 
AS SELECT \* FROM test;=
