### PR TITLE
Kryo update.

### DIFF
--- a/src/main/scala/shark/KryoRegistrator.scala
+++ b/src/main/scala/shark/KryoRegistrator.scala
@@ -24,8 +24,6 @@ import com.esotericsoftware.kryo.{Kryo, Serializer => KSerializer}
 import com.esotericsoftware.kryo.io.{Input => KryoInput, Output => KryoOutput}
 import com.esotericsoftware.kryo.serializers.{JavaSerializer => KryoJavaSerializer}
 
-import de.javakaffee.kryoserializers.ArraysAsListSerializer
-
 import org.apache.hadoop.io.Writable
 import org.apache.hadoop.hive.ql.exec.persistence.{MapJoinSingleKey, MapJoinObjectKey,
     MapJoinDoubleKeys, MapJoinObjectValue}
@@ -35,10 +33,6 @@ class KryoRegistrator extends spark.KryoRegistrator {
   def registerClasses(kryo: Kryo) {
 
     kryo.register(classOf[execution.ReduceKey])
-
-    // Java Arrays.asList returns an internal class that cannot be serialized
-    // by default Kryo. This provides a workaround.
-    kryo.register(Arrays.asList().getClass, new ArraysAsListSerializer)
 
     // The map join data structures are Java serializable.
     kryo.register(classOf[MapJoinSingleKey], new KryoJavaSerializer)


### PR DESCRIPTION
Removed de.javakaffee.kryoserializers.ArraysAsListSerializer reference because Spark's chill-java library will take care of that.
