### PR TITLE
Hive 0.11 compatibility

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -32,6 +32,7 @@ object SharkBuild extends Build {
   val HADOOP_VERSION = "1.0.4"
 
   // Whether to build Shark with Tachyon jar.
+  // Hive 0.10+ uses newer Thrift versions that conflict with Tachyon's
   val TACHYON_ENABLED = false
 
   lazy val root = Project(
@@ -90,7 +91,8 @@ object SharkBuild extends Build {
       "org.spark-project" %% "spark-core" % SPARK_VERSION,
       "org.spark-project" %% "spark-repl" % SPARK_VERSION,
       "com.google.guava" % "guava" % "14.0.1",
-      "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION,
+      // Differences in Jackson version cause runtime errors as per HIVE-3581
+      "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION excludeAll( ExclusionRule(organization = "org.codehaus.jackson") ),
       // See https://code.google.com/p/guava-libraries/issues/detail?id=1095
       "com.google.code.findbugs" % "jsr305" % "1.3.+",
       "it.unimi.dsi" % "fastutil" % "6.4.2",

--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -157,7 +157,7 @@ object SharkCliDriver {
     var reader = new ConsoleReader()
     reader.setBellEnabled(false)
     // reader.setDebug(new PrintWriter(new FileWriter("writer.debug", true)))
-    reader.addCompletor(CliDriver.getCommandCompletor())
+    CliDriver.getCommandCompletor().foreach((e) => reader.addCompletor(e))
 
     var line: String = null
     val HISTORYFILE = ".hivehistory"

--- a/src/main/scala/shark/SharkOptimizer.scala
+++ b/src/main/scala/shark/SharkOptimizer.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California. 
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark
+
+import java.util.{List => JavaList}
+
+import org.apache.hadoop.hive.ql.optimizer.{Optimizer => HiveOptimizer, 
+  SimpleFetchOptimizer, Transform}
+import org.apache.hadoop.hive.ql.parse.{ParseContext}
+
+class SharkOptimizer extends HiveOptimizer with LogHelper {
+
+  /**
+   * Override Hive optimizer to skip SimpleFetchOptimizer, which is designed 
+   * to let Hive avoid launching MR jobs on simple queries, but rewrites the 
+   * query plan in a way that is inconvenient for Shark (replaces the FS operator 
+   *with a non-terminal ListSink operator).
+   */
+  override def optimize(): ParseContext  = {
+
+    // Use reflection to make some private members accessible.
+    val transformationsField = classOf[HiveOptimizer].getDeclaredField("transformations")
+    val pctxField = classOf[HiveOptimizer].getDeclaredField("pctx")
+    pctxField.setAccessible(true)
+    transformationsField.setAccessible(true)
+    val transformations = transformationsField.get(this).asInstanceOf[JavaList[Transform]]
+    var pctx = pctxField.get(this).asInstanceOf[ParseContext]
+
+    // Invoke each optimizer transformation
+    val it = transformations.iterator
+    while (it.hasNext()) {
+      val transformation = it.next()
+      transformation match {
+        case _:SimpleFetchOptimizer => {}
+        case _ => {
+          pctx = transformation.transform(pctx)
+        }
+      }
+    }
+    pctx
+  }
+}

--- a/src/main/scala/shark/execution/CommonJoinOperator.scala
+++ b/src/main/scala/shark/execution/CommonJoinOperator.scala
@@ -17,7 +17,7 @@
 
 package shark.execution
 
-import java.util.{HashMap => JavaHashMap, List => JavaList}
+import java.util.{List => JavaList}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._
@@ -50,17 +50,20 @@ abstract class CommonJoinOperator[JOINDESCTYPE <: JoinDesc, T <: HiveCommonJoinO
   @BeanProperty var nullCheck: Boolean = _
 
   @transient
-  var joinVals: JavaHashMap[java.lang.Byte, JavaList[ExprNodeEvaluator]] = _
+  var tagLen: Int = _
   @transient
-  var joinFilters: JavaHashMap[java.lang.Byte, JavaList[ExprNodeEvaluator]] = _
+  var joinVals: Array[JavaList[ExprNodeEvaluator]] = _
   @transient
-  var joinValuesObjectInspectors: JavaHashMap[java.lang.Byte, JavaList[ObjectInspector]] = _
+  var joinFilters: Array[JavaList[ExprNodeEvaluator]] = _
   @transient
-  var joinFilterObjectInspectors: JavaHashMap[java.lang.Byte, JavaList[ObjectInspector]] = _
+  var joinValuesObjectInspectors: Array[JavaList[ObjectInspector]] = _
   @transient
-  var joinValuesStandardObjectInspectors: JavaHashMap[java.lang.Byte, JavaList[ObjectInspector]] = _
+  var joinFilterObjectInspectors: Array[JavaList[ObjectInspector]] = _
+  @transient
+  var joinValuesStandardObjectInspectors: Array[JavaList[ObjectInspector]] = _
 
   @transient var noOuterJoin: Boolean = _
+  @transient var filterMap: Array[Array[Int]] = _
 
   override def initializeOnMaster() {
     conf = hiveOp.getConf()
@@ -76,21 +79,24 @@ abstract class CommonJoinOperator[JOINDESCTYPE <: JoinDesc, T <: HiveCommonJoinO
   override def initializeOnSlave() {
 
     noOuterJoin = conf.isNoOuterJoin
+    filterMap = conf.getFilterMap
 
-    joinVals = new JavaHashMap[java.lang.Byte, JavaList[ExprNodeEvaluator]]
+    tagLen = conf.getTagLength()
+
+    joinVals = new Array[JavaList[ExprNodeEvaluator]](tagLen)
     HiveJoinUtil.populateJoinKeyValue(
       joinVals, conf.getExprs(), order, CommonJoinOperator.NOTSKIPBIGTABLE)
 
-    joinFilters = new JavaHashMap[java.lang.Byte, JavaList[ExprNodeEvaluator]]
+    joinFilters = new Array[JavaList[ExprNodeEvaluator]](tagLen)
     HiveJoinUtil.populateJoinKeyValue(
       joinFilters, conf.getFilters(), order, CommonJoinOperator.NOTSKIPBIGTABLE)
 
     joinValuesObjectInspectors = HiveJoinUtil.getObjectInspectorsFromEvaluators(
-      joinVals, objectInspectors.toArray, CommonJoinOperator.NOTSKIPBIGTABLE)
+      joinVals, objectInspectors.toArray, CommonJoinOperator.NOTSKIPBIGTABLE, tagLen)
     joinFilterObjectInspectors = HiveJoinUtil.getObjectInspectorsFromEvaluators(
-      joinFilters, objectInspectors.toArray, CommonJoinOperator.NOTSKIPBIGTABLE)
+      joinFilters, objectInspectors.toArray, CommonJoinOperator.NOTSKIPBIGTABLE, tagLen)
     joinValuesStandardObjectInspectors = HiveJoinUtil.getStandardObjectInspectors(
-      joinValuesObjectInspectors, CommonJoinOperator.NOTSKIPBIGTABLE)
+      joinValuesObjectInspectors, CommonJoinOperator.NOTSKIPBIGTABLE, tagLen)
   }
 }
 

--- a/src/main/scala/shark/execution/JoinOperator.scala
+++ b/src/main/scala/shark/execution/JoinOperator.scala
@@ -144,7 +144,7 @@ class JoinOperator extends CommonJoinOperator[JoinDesc, HiveJoinOperator]
     val bytes = new BytesWritable
     val tmp = new Array[Object](2)
 
-    val tupleSizes = (0 until joinVals.size).map { i => joinVals.get(i.toByte).size() }.toIndexedSeq
+    val tupleSizes = joinVals.map((e) => e.size).toIndexedSeq
     val offsets = tupleSizes.scanLeft(0)(_ + _)
 
     val rowSize = offsets.last
@@ -156,14 +156,14 @@ class JoinOperator extends CommonJoinOperator[JoinDesc, HiveJoinOperator]
         val element = elements(index).asInstanceOf[Array[Byte]]
         var i = 0
         if (element == null) {
-          while (i < joinVals.get(index.toByte).size) {
+          while (i < joinVals(index).size) {
             outputRow(i + offsets(index)) = null
             i += 1
           }
         } else {
           bytes.set(element, 0, element.length)
           tmp(1) = tagToValueSer.get(index).deserialize(bytes)
-          val joinVal = joinVals.get(index.toByte)
+          val joinVal = joinVals(index)
           while (i < joinVal.size) {
             outputRow(i + offsets(index)) = joinVal(i).evaluate(tmp)
             i += 1

--- a/src/main/scala/shark/execution/MapJoinOperator.scala
+++ b/src/main/scala/shark/execution/MapJoinOperator.scala
@@ -47,11 +47,11 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
   @BeanProperty var bigTableAlias: Int = _
   @BeanProperty var bigTableAliasByte: java.lang.Byte = _
 
-  @transient var joinKeys: JHashMap[java.lang.Byte, JList[ExprNodeEvaluator]] = _
-  @transient var joinKeysObjectInspectors: JHashMap[java.lang.Byte, JList[ObjectInspector]] = _
+  @transient var joinKeys: Array[JList[ExprNodeEvaluator]] = _
+  @transient var joinKeysObjectInspectors: Array[JList[ObjectInspector]] = _
 
   @transient val metadataKeyTag = -1
-  @transient var joinValues: JHashMap[java.lang.Byte, JList[ExprNodeEvaluator]] = _
+  @transient var joinValues: Array[JList[ExprNodeEvaluator]] = _
 
   override def initializeOnMaster() {
     super.initializeOnMaster()
@@ -68,14 +68,15 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
   override def initializeOnSlave() {
     super.initializeOnSlave()
 
-    joinKeys = new JHashMap[java.lang.Byte, JList[ExprNodeEvaluator]]
+    tagLen = conf.getTagLength()
+    joinKeys = new Array[JList[ExprNodeEvaluator]](tagLen)
     HiveJoinUtil.populateJoinKeyValue(
       joinKeys, conf.getKeys(), order, CommonJoinOperator.NOTSKIPBIGTABLE)
 
     // A bit confusing but getObjectInspectorsFromEvaluators also initializes
     // the evaluators.
     joinKeysObjectInspectors = HiveJoinUtil.getObjectInspectorsFromEvaluators(
-      joinKeys, objectInspectors.toArray, CommonJoinOperator.NOTSKIPBIGTABLE)
+      joinKeys, objectInspectors.toArray, CommonJoinOperator.NOTSKIPBIGTABLE, tagLen)
 
   }
 
@@ -173,15 +174,15 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
     iter.foreach { row =>
       val key = JoinUtil.computeJoinKey(
         row,
-        joinKeys.get(posByte),
-        joinKeysObjectInspectors.get(posByte))
+        joinKeys(posByte),
+        joinKeysObjectInspectors(posByte))
       val value: Array[AnyRef] = JoinUtil.computeJoinValues(
         row,
-        joinVals.get(posByte),
-        joinValuesObjectInspectors.get(posByte),
-        joinFilters.get(posByte),
-        joinFilterObjectInspectors.get(posByte),
-        noOuterJoin)
+        joinVals(posByte),
+        joinValuesObjectInspectors(posByte),
+        joinFilters(posByte),
+        joinFilterObjectInspectors(posByte),
+        (filterMap == null))
       // If we've seen the key before, just add it to the row container wrapped by
       // corresponding MapJoinObjectValue.
       val objValue = valueMap.get(key)
@@ -202,8 +203,8 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
   def joinOnPartition[T](iter: Iterator[T],
       hashtables: Map[Int, JHashMap[Seq[AnyRef], Array[Array[AnyRef]]]]): Iterator[_] = {
 
-    val joinKeyEval = joinKeys.get(bigTableAlias.toByte)
-    val joinValueEval = joinVals.get(bigTableAlias.toByte)
+    val joinKeyEval = joinKeys(bigTableAlias)
+    val joinValueEval = joinVals(bigTableAlias)
     val bufs = new Array[Seq[Array[Object]]](numTables)
     val nullSafes = conf.getNullSafes()
 
@@ -214,14 +215,15 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
       val key = JoinUtil.computeJoinKey(
         row,
         joinKeyEval,
-        joinKeysObjectInspectors.get(bigTableAliasByte))
+        joinKeysObjectInspectors(bigTableAlias))
       val v: Array[AnyRef] = JoinUtil.computeJoinValues(
         row,
         joinValueEval,
-        joinValuesObjectInspectors.get(bigTableAliasByte),
-        joinFilters.get(bigTableAliasByte),
-        joinFilterObjectInspectors.get(bigTableAliasByte),
-        noOuterJoin)
+        joinValuesObjectInspectors(bigTableAlias),
+        joinFilters(bigTableAlias),
+        joinFilterObjectInspectors(bigTableAlias),
+        (filterMap == null))
+
       val value = new Array[AnyRef](v.size)
       Range(0,v.size).foreach(i => value(i) = v(i).asInstanceOf[SerializableWritable[_]].value)
 
@@ -251,7 +253,7 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
         cp.product(bufs, joinConditions)
       }
     }
-    val rowSize = joinVals.values.map(_.size).sum
+    val rowSize = joinVals.map(_.size).sum
     val rowToReturn = new Array[Object](rowSize)
     // For each row, combine the tuples from multiple tables into a single tuple.
     jointRows.map { row: Array[Array[Object]] =>

--- a/src/main/scala/shark/execution/ScriptOperatorHelper.scala
+++ b/src/main/scala/shark/execution/ScriptOperatorHelper.scala
@@ -36,11 +36,11 @@ class ScriptOperatorHelper(val op: ScriptOperator) extends ScriptOperator {
 
   def getAlias: String = op.alias
 
-  def addJobConfToEnvironment(conf: Configuration, env: JMap[String, String]) {
-    ScriptOperator.addJobConfToEnvironment(conf, env)
+  override def addJobConfToEnvironment(conf: Configuration, env: JMap[String, String]) {
+    op.addJobConfToEnvironment(conf, env)
   }
 
-  def safeEnvVarName(variable: String): String = {
-    ScriptOperator.safeEnvVarName(variable)
+  override def safeEnvVarName(variable: String): String = {
+    op.safeEnvVarName(variable)
   }
 }

--- a/src/main/scala/shark/execution/SharkExplainTask.scala
+++ b/src/main/scala/shark/execution/SharkExplainTask.scala
@@ -26,6 +26,7 @@ import scala.collection.JavaConversions._
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.exec.{ExplainTask, Task}
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.{Context, DriverContext, QueryPlan}
 import org.apache.hadoop.hive.ql.plan.{Explain, ExplainWork}
 import org.apache.hadoop.hive.ql.plan.api.StageType
@@ -38,8 +39,9 @@ class SharkExplainWork(
   resFile: String,
   rootTasks: JavaList[Task[_ <: java.io.Serializable]],
   astStringTree: String,
+  inputs: HashSet[ReadEntity],
   extended: Boolean)
- extends ExplainWork(resFile, rootTasks, astStringTree, extended, false)
+ extends ExplainWork(resFile, rootTasks, astStringTree, inputs, extended, false, false)
 
 
 /**

--- a/src/main/scala/shark/execution/TableScanOperator.scala
+++ b/src/main/scala/shark/execution/TableScanOperator.scala
@@ -23,7 +23,7 @@ import scala.reflect.BeanProperty
 
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf}
 import org.apache.hadoop.hive.conf.HiveConf
-import org.apache.hadoop.hive.metastore.api.Constants.META_TABLE_PARTITION_COLUMNS
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_PARTITION_COLUMNS
 import org.apache.hadoop.hive.ql.exec.{TableScanOperator => HiveTableScanOperator}
 import org.apache.hadoop.hive.ql.exec.{MapSplitPruning, Utilities}
 import org.apache.hadoop.hive.ql.metadata.{Partition, Table}
@@ -284,7 +284,7 @@ class TableScanOperator extends TopOperator[HiveTableScanOperator] with HiveTopO
     }
     new HiveInputFormat() {
       def doPushFilters() {
-        pushFilters(conf, hiveOp)
+        HiveInputFormat.pushFilters(conf, hiveOp)
       }
     }.doPushFilters()
     FileInputFormat.setInputPaths(conf, path)

--- a/src/main/scala/shark/parse/SharkExplainSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkExplainSemanticAnalyzer.scala
@@ -62,7 +62,7 @@ class SharkExplainSemanticAnalyzer(conf: HiveConf) extends ExplainSemanticAnalyz
     }
 
     val task = TaskFactory.get(
-      new SharkExplainWork(ctx.getResFile().toString(), tasks, childNode.toStringTree(), extended),
+      new SharkExplainWork(ctx.getResFile().toString(), tasks, childNode.toStringTree(), sem.getInputs(), extended),
       conf)
 
     rootTasks.add(task)

--- a/src/main/scala/shark/parse/SharkExplainSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkExplainSemanticAnalyzer.scala
@@ -62,8 +62,8 @@ class SharkExplainSemanticAnalyzer(conf: HiveConf) extends ExplainSemanticAnalyz
     }
 
     val task = TaskFactory.get(
-      new SharkExplainWork(ctx.getResFile().toString(), tasks, childNode.toStringTree(), sem.getInputs(), extended),
-      conf)
+      new SharkExplainWork(ctx.getResFile().toString(), tasks, childNode.toStringTree(), 
+        sem.getInputs(), extended), conf)
 
     rootTasks.add(task)
   }

--- a/src/test/java/shark/SharkQTestUtil.java
+++ b/src/test/java/shark/SharkQTestUtil.java
@@ -12,6 +12,8 @@ import org.apache.hadoop.hive.ql.QTestUtil;
 import org.apache.hadoop.hive.ql.exec.Utilities.StreamPrinter;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 /**
  * Replaces Hive's QTestUtil class by using the SharkDriver instead of Hive's
  * Driver. Also changes the way comparison is done by forcing a sort and
@@ -20,6 +22,8 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 public class SharkQTestUtil extends QTestUtil {
 
   private static Method maskPatternsMethod;
+
+  static final private Log LOG = LogFactory.getLog(SharkQTestUtil.class.getName());
 
   static {
     try {
@@ -81,7 +85,7 @@ public class SharkQTestUtil extends QTestUtil {
       try {
         ss.initFiles.add(testInitFile.getAbsolutePath());
       } catch (Exception e) {
-        System.out.println("Exceptione is =" + e.getMessage());
+        System.out.println("Exception is =" + e.getMessage());
       }
     }
     cliDrv.processInitFiles(ss);
@@ -89,6 +93,7 @@ public class SharkQTestUtil extends QTestUtil {
 
   @Override
   public int executeClient(String tname) {
+    LOG.info("Begin query: " + tname);
     return cliDrv.processLine(getQMap().get(tname));
   }
 


### PR DESCRIPTION
Initial commit of support for Hive 0.11. This compiles and runs as expected, passing most regression tests, though more thorough testing is still in progress. Does not yet include support for new Hive 0.11 operators (e.g. PTFOperator) or new stats features. 
