### PR TITLE
Reorder materialization and cache insertion

### DIFF
--- a/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
+++ b/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
@@ -122,13 +122,13 @@ class MemoryStoreSinkOperator extends TerminalOperator {
 
       // Force evaluate so the data gets put into Spark block manager.
       rdd.persist(storageLevel)
-      rdd.foreach(_ => Unit)
-
+      val origRdd = rdd
       if (useUnionRDD) {
         rdd = rdd.union(
           SharkEnv.memoryMetadataManager.get(tableName).get.asInstanceOf[RDD[TablePartition]])
       }
       SharkEnv.memoryMetadataManager.put(tableName, rdd)
+      origRdd.foreach(_ => Unit)
     }
 
     // Report remaining memory.


### PR DESCRIPTION
In case of failures during materialization the current ordering means we cannot clean up RDDs that are cached when the table creation fails.
This patch fixes the cleanup issue by ordering table creation first followed by RDD materialization.
