### PR TITLE
Column Pruning

### DIFF
--- a/src/main/scala/shark/execution/optimization/ColumnPruner.scala
+++ b/src/main/scala/shark/execution/optimization/ColumnPruner.scala
@@ -1,0 +1,95 @@
+package shark.execution.optimization
+
+import java.util.BitSet
+import java.util.{List => JList}
+import scala.collection.JavaConversions.{asScalaBuffer, 
+  bufferAsJavaList, collectionAsScalaIterable}
+import scala.collection.mutable.{Set, HashSet}
+import org.apache.hadoop.hive.ql.exec.GroupByPreShuffleOperator
+import org.apache.hadoop.hive.ql.metadata.Table
+import org.apache.hadoop.hive.ql.plan.SelectDesc
+import shark.execution.{FilterOperator, JoinOperator, 
+  MapJoinOperator, Operator, ReduceSinkOperator,
+  SelectOperator, TopOperator}
+import shark.memstore2.{ColumnarStruct, TablePartitionIterator}
+import org.apache.hadoop.hive.ql.plan.{FilterDesc, MapJoinDesc, ReduceSinkDesc}
+
+
+class ColumnPruner(@transient op: TopOperator[_], @transient tbl: Table) extends Serializable {
+
+  val columnsUsed: BitSet = {
+    val colsToKeep = computeColumnsToKeep()
+    val allColumns = tbl.getAllCols().map(x => x.getName())
+    var b = new BitSet()
+    for (i <- Range(0, allColumns.size()) if (colsToKeep.contains(allColumns(i)))) {
+      b.set(i, true)
+    }
+    b
+  }
+
+  private def computeColumnsToKeep(): Set[String] = {
+    val cols = HashSet[String]()
+    computeColumnsToKeep(op, cols)
+    cols
+  }
+
+  /**
+   * Computes the column names that are referenced in the Query
+   */
+  private def computeColumnsToKeep(op: Operator[_],
+    cols: HashSet[String], parentOp: Operator[_] = null): Unit = {
+    def nullGuard[T](s: JList[T]): Seq[T] = {
+      if (s == null) Seq[T]() else s
+    }
+    op match {
+      case selOp: SelectOperator => {
+        val cnf:SelectDesc = selOp.getConf
+        //Select Descriptor contains SelectConf, which holds the list of columns
+        //referenced by the select op
+        if (cnf != null) {
+          val evals = nullGuard(cnf.getColList)
+          cols ++= (HashSet() ++ evals).flatMap(x => nullGuard(x.getCols))
+        }
+      }
+      case filterOp: FilterOperator => {
+        val cnf:FilterDesc = filterOp.getConf
+        //FilterDesc has predicates, which are the columns involved in predicate operations
+        if (cnf != null) {
+          cols ++= (HashSet() ++ nullGuard(cnf.getPredicate.getCols))
+        }
+      }
+      case joinOp: JoinOperator => {
+        val cnf:ReduceSinkDesc = parentOp.asInstanceOf[ReduceSinkOperator].getConf
+        //before a regular join operation, the reduce sink operator is always present.
+        //the key and value columns need to be examined for the input to the join
+        if (cnf != null) {
+          val keyEvals = nullGuard(cnf.getKeyCols)
+          val valEvals = nullGuard(cnf.getValueCols)
+          val evals = (HashSet() ++ keyEvals ++ valEvals)
+          cols ++= evals.flatMap(x => nullGuard(x.getCols))
+        }
+      }
+      case joinOp: MapJoinOperator => {
+        val cnf:MapJoinDesc = joinOp.getConf
+        if (cnf != null) {
+          val keyEvals = cnf.getKeys.values
+          val valEvals = cnf.getExprs.values
+          val evals = (HashSet() ++ keyEvals ++ valEvals)
+          cols ++= evals.flatMap(x => x).flatMap(x => nullGuard(x.getCols))
+        }
+      }
+      case groupBy: GroupByPreShuffleOperator => {
+        val cnf = groupBy.getConf
+        if (cnf != null) {
+          val keys = nullGuard(groupBy.getConf.getKeys)
+          cols ++= (HashSet() ++ keys).flatMap(x => nullGuard(x.getCols))
+        }
+      }
+      case _ =>
+    }
+    //recurse on the subtree
+    op.childOperators.foreach { y =>
+      computeColumnsToKeep(y, cols, op)
+    }
+  }
+}

--- a/src/main/scala/shark/memstore2/TablePartition.scala
+++ b/src/main/scala/shark/memstore2/TablePartition.scala
@@ -20,6 +20,7 @@ package shark.memstore2
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.BitSet
 import shark.memstore2.column.ColumnIterator
 
 
@@ -70,6 +71,15 @@ class TablePartition(private var _numRows: Long, private var _columns: Array[Byt
       iter
     }
     new TablePartitionIterator(_numRows, columnIterators)
+  }
+
+  def prunedIterator(columnsUsed: BitSet) = {
+    val columnIterators: Array[ColumnIterator] = _columns.map {
+      case buffer: ByteBuffer =>
+        val iter = ColumnIterator.newIterator(buffer)
+        iter
+    }
+    new TablePartitionIterator(_numRows, columnIterators, columnsUsed)
   }
 
   override def readExternal(in: ObjectInput) {

--- a/src/main/scala/shark/memstore2/TablePartitionIterator.scala
+++ b/src/main/scala/shark/memstore2/TablePartitionIterator.scala
@@ -17,8 +17,8 @@
 
 package shark.memstore2
 
-import scala.collection.immutable.BitSet
-
+import java.nio.ByteBuffer
+import java.util.BitSet
 import shark.memstore2.column.ColumnIterator
 
 
@@ -28,36 +28,45 @@ import shark.memstore2.column.ColumnIterator
  *
  * @param numRows: total number of rows in this partition.
  * @param columnIterators: iterators for all columns.
- * @param columnUsed: an optional bitmap indicating whether a column is used.
+ @ @param columnUsed: an optional bitmap indicating whether a column is used.
  */
 class TablePartitionIterator(
     val numRows: Long,
     val columnIterators: Array[ColumnIterator],
-    val columnUsed: BitSet = null)
+    val columnUsed: BitSet)
   extends Iterator[ColumnarStruct] {
+
+  def this(numRows: Long, 
+      columnIterators: Array[ColumnIterator]) {
+    this(numRows, columnIterators, TablePartitionIterator.newBitSet(columnIterators.size))
+  }
 
   private val _struct = new ColumnarStruct(columnIterators)
 
   private var _position: Long = 0
 
-  def hasNext: Boolean = _position < numRows
+  def hasNext(): Boolean = _position < numRows
 
   def next(): ColumnarStruct = {
     _position += 1
-    var i = 0
-    while (i < _columnIteratorsToAdvance.size) {
-      _columnIteratorsToAdvance(i).next
-      i += 1
+    var i = columnUsed.nextSetBit(0)
+    while (i > -1) {
+      columnIterators(i).next
+      i = columnUsed.nextSetBit(i + 1)
     }
     _struct
   }
+}
 
-  // Track the list of columns we need to call next on.
-  private val _columnIteratorsToAdvance: Array[ColumnIterator] = {
-    if (columnUsed == null) {
-      columnIterators
-    } else {
-      columnUsed.map(colId => columnIterators(colId)).toArray
+object TablePartitionIterator {
+  
+  def newBitSet(numCols: Int): BitSet = {
+    val b = new BitSet(numCols)
+    var i = numCols 
+    while (i > 0) {
+      i -= 1
+      b.set(i, true)
     }
+    b
   }
 }

--- a/src/test/scala/shark/SQLSuite.scala
+++ b/src/test/scala/shark/SQLSuite.scala
@@ -298,6 +298,28 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   //////////////////////////////////////////////////////////////////////////////
+  // Tableau bug
+  //////////////////////////////////////////////////////////////////////////////
+
+  test("tableau bug / adw") {
+    sc.sql("drop table if exists adw")
+    sc.sql("""create table adw TBLPROPERTIES ("shark.cache" = "true") as
+      select cast(key as int) as k, val from test""")
+    expectSql("select count(k) from adw where val='val_487' group by 1 having count(1) > 0","1")
+  }
+  
+   //////////////////////////////////////////////////////////////////////////////
+  // Sel Star
+  //////////////////////////////////////////////////////////////////////////////
+  
+  test("sel star pruning") {
+    sc.sql("drop table if exists selstar")
+    sc.sql("""create table selstar TBLPROPERTIES ("shark.cache" = "true") as
+      select * from test""")
+    expectSql("select * from selstar where val='val_487'","487	val_487")
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
   // SharkContext APIs (e.g. sql2rdd, sql)
   //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This patch prunes away columns that are not used in a query so that the  table partition iterator can skip over those columns while iterating
