### PR TITLE
Consistent naming for storage levels

### DIFF
--- a/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
+++ b/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
@@ -93,11 +93,11 @@ object MemoryMetadataManager {
       s.toUpperCase match {
         case "NONE" => StorageLevel.NONE
         case "DISK_ONLY" => StorageLevel.DISK_ONLY
-        case "DISK_ONLY2" => StorageLevel.DISK_ONLY_2
+        case "DISK_ONLY_2" => StorageLevel.DISK_ONLY_2
         case "MEMORY_ONLY" => StorageLevel.MEMORY_ONLY
         case "MEMORY_ONLY_2" => StorageLevel.MEMORY_ONLY_2
         case "MEMORY_ONLY_SER" => StorageLevel.MEMORY_ONLY_SER
-        case "MEMORY_ONLY_SER2" => StorageLevel.MEMORY_ONLY_SER_2
+        case "MEMORY_ONLY_SER_2" => StorageLevel.MEMORY_ONLY_SER_2
         case "MEMORY_AND_DISK" => StorageLevel.MEMORY_AND_DISK
         case "MEMORY_AND_DISK_2" => StorageLevel.MEMORY_AND_DISK_2
         case "MEMORY_AND_DISK_SER" => StorageLevel.MEMORY_AND_DISK_SER


### PR DESCRIPTION
Is there any reason for not making the string names consistent?
