### PR TITLE
Throw exception if Hive thinks it's running in local mode

### DIFF
--- a/src/main/scala/shark/execution/FileSinkOperator.scala
+++ b/src/main/scala/shark/execution/FileSinkOperator.scala
@@ -120,11 +120,9 @@ class FileSinkOperator extends TerminalOperator with Serializable {
     val inputRdd = if (parentOperators.size == 1) executeParents().head._2 else null
     val rdd = preprocessRdd(inputRdd)
 
-    val master = rdd.context.master
-    val sparkIsLocal = (master == "local" || master.startsWith("local["))
     val hiveIslocal = ShimLoader.getHadoopShims.isLocalMode(hconf)
-    if (!sparkIsLocal && hiveIslocal) {
-      val intro = "Hive's Hadoop shim detected local mode even though Shark is not running locally.\n"
+    if (!rdd.context.isLocal && hiveIslocal) {
+      val intro = "Hive Hadoop shims detected local mode even though Shark is not running locally.\n"
       val jtCheck = "mapred.job.tracker should be specified and not 'local'. Value: %s.\n".format(
         hconf.get("mapred.job.tracker"))
       val fnCheck = "mapreduce.framework.name should be specified and not 'local'. Value: %s.\n".format(

--- a/src/main/scala/shark/execution/FileSinkOperator.scala
+++ b/src/main/scala/shark/execution/FileSinkOperator.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.exec.{FileSinkOperator => HiveFileSinkOperator}
 import org.apache.hadoop.hive.ql.exec.JobCloseFeedBack
+import org.apache.hadoop.hive.shims.ShimLoader
 import org.apache.hadoop.mapred.TaskID
 import org.apache.hadoop.mapred.TaskAttemptID
 import org.apache.hadoop.mapred.SparkHadoopWriter
@@ -118,6 +119,18 @@ class FileSinkOperator extends TerminalOperator with Serializable {
   override def execute(): RDD[_] = {
     val inputRdd = if (parentOperators.size == 1) executeParents().head._2 else null
     val rdd = preprocessRdd(inputRdd)
+
+    val master = rdd.context.master
+    val sparkIsLocal = (master == "local" || master.startsWith("local["))
+    val hiveIslocal = ShimLoader.getHadoopShims.isLocalMode(hconf)
+    if (!sparkIsLocal && hiveIslocal) {
+      val intro = "Hive's Hadoop shim detected local mode even though Shark is not running locally.\n"
+      val jtCheck = "mapred.job.tracker should be specified and not 'local'. Value: %s.\n".format(
+        hconf.get("mapred.job.tracker"))
+      val fnCheck = "mapreduce.framework.name should be specified and not 'local'. Value: %s.\n".format(
+        hconf.get("mapreduce.framework.name"))
+      throw new Exception(intro + jtCheck + fnCheck)
+    }
 
     parentOperators.head match {
       case op: LimitOperator =>


### PR DESCRIPTION
This throws a descriptive error message if a user tries to run Shark in a way that will result in query responses being silently dropped.
