### PR TITLE
Add a new 'shark.cache.type' table property. Also included are a few comments and some small refactoring.

### DIFF
--- a/src/main/scala/shark/execution/TableScanOperator.scala
+++ b/src/main/scala/shark/execution/TableScanOperator.scala
@@ -114,9 +114,8 @@ class TableScanOperator extends TopOperator[HiveTableScanOperator] with HiveTopO
 
     // There are three places we can load the table from.
     // 1. Tachyon table
-    // 2. Spark heap (block manager)
+    // 2. Spark heap (block manager), accessed through the Shark MemoryMetadataManager
     // 3. Hive table on HDFS (or other Hadoop storage)
-
     val cacheMode = CacheType.fromString(
       tableDesc.getProperties().get("shark.cache").asInstanceOf[String])
     if (cacheMode == CacheType.HEAP) {

--- a/src/main/scala/shark/execution/TableScanOperator.scala
+++ b/src/main/scala/shark/execution/TableScanOperator.scala
@@ -119,7 +119,7 @@ class TableScanOperator extends TopOperator[HiveTableScanOperator] with HiveTopO
 
     val cacheMode = CacheType.fromString(
       tableDesc.getProperties().get("shark.cache").asInstanceOf[String])
-    if (cacheMode == CacheType.heap) {
+    if (cacheMode == CacheType.HEAP) {
       // Table should be in Spark heap (block manager).
       val rdd = SharkEnv.memoryMetadataManager.get(tableKey).getOrElse {
         logError("""|Table %s not found in block manager.
@@ -129,7 +129,7 @@ class TableScanOperator extends TopOperator[HiveTableScanOperator] with HiveTopO
       }
       logInfo("Loading table " + tableKey + " from Spark block manager")
       createPrunedRdd(tableKey, rdd)
-    } else if (cacheMode == CacheType.tachyon) {
+    } else if (cacheMode == CacheType.TACHYON) {
       // Table is in Tachyon.
       if (!SharkEnv.tachyonUtil.tableExists(tableKey)) {
         throw new TachyonException("Table " + tableKey + " does not exist in Tachyon")

--- a/src/main/scala/shark/execution/TableScanOperator.scala
+++ b/src/main/scala/shark/execution/TableScanOperator.scala
@@ -117,7 +117,7 @@ class TableScanOperator extends TopOperator[HiveTableScanOperator] with HiveTopO
     // 2. Spark heap (block manager), accessed through the Shark MemoryMetadataManager
     // 3. Hive table on HDFS (or other Hadoop storage)
     val cacheMode = CacheType.fromString(
-      tableDesc.getProperties().get("shark.cache").asInstanceOf[String])
+      tableDesc.getProperties().get("shark.cache.type").asInstanceOf[String])
     if (cacheMode == CacheType.HEAP) {
       // Table should be in Spark heap (block manager).
       val rdd = SharkEnv.memoryMetadataManager.get(tableKey).getOrElse {

--- a/src/main/scala/shark/execution/TableScanOperator.scala
+++ b/src/main/scala/shark/execution/TableScanOperator.scala
@@ -117,7 +117,7 @@ class TableScanOperator extends TopOperator[HiveTableScanOperator] with HiveTopO
     // 2. Spark heap (block manager), accessed through the Shark MemoryMetadataManager
     // 3. Hive table on HDFS (or other Hadoop storage)
     val cacheMode = CacheType.fromString(
-      tableDesc.getProperties().get("shark.cache.type").asInstanceOf[String])
+      tableDesc.getProperties().get("shark.cache").asInstanceOf[String])
     if (cacheMode == CacheType.HEAP) {
       // Table should be in Spark heap (block manager).
       val rdd = SharkEnv.memoryMetadataManager.get(tableKey).getOrElse {

--- a/src/main/scala/shark/memstore2/CacheType.scala
+++ b/src/main/scala/shark/memstore2/CacheType.scala
@@ -21,19 +21,19 @@ package shark.memstore2
 object CacheType extends Enumeration {
 
   type CacheType = Value
-  val none, heap, tachyon = Value
+  val NONE, HEAP, TACHYON = Value
 
-  def shouldCache(c: CacheType): Boolean = (c != none)
+  def shouldCache(c: CacheType): Boolean = (c != NONE)
 
   /** Get the cache type object from a string representation. */
   def fromString(name: String): CacheType = {
     if (name == null || name == "") {
-      none
+      NONE
     } else if (name.toLowerCase == "true") {
-      heap
+      HEAP
     } else {
       try {
-        withName(name.toLowerCase)
+        withName(name.toUpperCase)
       } catch {
         case e: java.util.NoSuchElementException => throw new InvalidCacheTypeException(name)
       }

--- a/src/main/scala/shark/memstore2/CacheType.scala
+++ b/src/main/scala/shark/memstore2/CacheType.scala
@@ -17,9 +17,17 @@
 
 package shark.memstore2
 
-
+/*
+ * Enumerations and static helper functions for cache types that can be used by Shark.
+ */
 object CacheType extends Enumeration {
 
+  /* The three CacheTypes:
+   * - NONE: On-disk storage (e.g. a Hive table that is stored in HDFS ).
+   * - HEAP: refers to Spark's block manager, which coordinates in-memory and on-disk RDD storage.
+   * - TACHYON: A distributed storage system that manages an in-memory cache for sharing files and
+   *            RDDs across cluster frameworks.
+   */
   type CacheType = Value
   val NONE, HEAP, TACHYON = Value
 
@@ -33,6 +41,7 @@ object CacheType extends Enumeration {
       HEAP
     } else {
       try {
+        // Try to use Scala's Enumeration::withName() to interpret 'name'.
         withName(name.toUpperCase)
       } catch {
         case e: java.util.NoSuchElementException => throw new InvalidCacheTypeException(name)
@@ -40,5 +49,6 @@ object CacheType extends Enumeration {
     }
   }
 
-  class InvalidCacheTypeException(name: String) extends Exception("Invalid cache type " + name)
+  class InvalidCacheTypeException(name: String)
+    extends Exception("Invalid string representation of cache type " + name)
 }

--- a/src/main/scala/shark/memstore2/CacheType.scala
+++ b/src/main/scala/shark/memstore2/CacheType.scala
@@ -22,7 +22,8 @@ package shark.memstore2
  */
 object CacheType extends Enumeration {
 
-  /* The CacheTypes:
+  /*
+   * The CacheTypes:
    * - NONE: On-disk storage (e.g. a Hive table that is stored in HDFS ).
    * - HEAP: refers to Spark's block manager, which coordinates in-memory and on-disk RDD storage.
    * - TACHYON: A distributed storage system that manages an in-memory cache for sharing files and
@@ -35,8 +36,10 @@ object CacheType extends Enumeration {
 
   /** Get the cache type object from a string representation. */
   def fromString(name: String): CacheType = {
-    if (name == null || name == "") {
+    if (name == null || name == "" || name.toLowerCase == "false") {
       NONE
+    } else if (name.toLowerCase == "true") {
+      HEAP
     } else {
       try {
         // Try to use Scala's Enumeration::withName() to interpret 'name'.

--- a/src/main/scala/shark/memstore2/CacheType.scala
+++ b/src/main/scala/shark/memstore2/CacheType.scala
@@ -18,11 +18,11 @@
 package shark.memstore2
 
 /*
- * Enumerations and static helper functions for cache types that can be used by Shark.
+ * Enumerations and static helper functions for caches supported by Shark.
  */
 object CacheType extends Enumeration {
 
-  /* The three CacheTypes:
+  /* The CacheTypes:
    * - NONE: On-disk storage (e.g. a Hive table that is stored in HDFS ).
    * - HEAP: refers to Spark's block manager, which coordinates in-memory and on-disk RDD storage.
    * - TACHYON: A distributed storage system that manages an in-memory cache for sharing files and
@@ -37,8 +37,6 @@ object CacheType extends Enumeration {
   def fromString(name: String): CacheType = {
     if (name == null || name == "") {
       NONE
-    } else if (name.toLowerCase == "true") {
-      HEAP
     } else {
       try {
         // Try to use Scala's Enumeration::withName() to interpret 'name'.

--- a/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
@@ -76,7 +76,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
 
     //TODO: can probably reuse Hive code for this
     // analyze create table command
-    var cacheMode = CacheType.none
+    var cacheMode = CacheType.NONE
     var isCTAS = false
     var shouldReset = false
 
@@ -101,13 +101,13 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
       } else {
         val checkTableName = SharkConfVars.getBoolVar(conf, SharkConfVars.CHECK_TABLENAME_FLAG)
         val cacheType = CacheType.fromString(td.getTblProps().get("shark.cache"))
-        if (cacheType == CacheType.heap ||
+        if (cacheType == CacheType.HEAP ||
           (td.getTableName.endsWith("_cached") && checkTableName)) {
-          cacheMode = CacheType.heap
+          cacheMode = CacheType.HEAP
           td.getTblProps().put("shark.cache", cacheMode.toString)
-        } else if (cacheType == CacheType.tachyon ||
+        } else if (cacheType == CacheType.TACHYON ||
           (td.getTableName.endsWith("_tachyon") && checkTableName)) {
-          cacheMode = CacheType.tachyon
+          cacheMode = CacheType.TACHYON
           td.getTblProps().put("shark.cache", cacheMode.toString)
         }
 
@@ -191,7 +191,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
                     cachedTableName,
                     storageLevel,
                     _resSchema.size,                // numColumns
-                    cacheMode == CacheType.tachyon, // use tachyon
+                    cacheMode == CacheType.TACHYON, // use tachyon
                     useUnionRDD)
                 } else {
                   throw new SemanticException(
@@ -215,7 +215,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
               qb.getTableDesc.getTableName,
               storageLevel,
               _resSchema.size,                // numColumns
-              cacheMode == CacheType.tachyon, // use tachyon
+              cacheMode == CacheType.TACHYON, // use tachyon
               false)
           } else if (pctx.getContext().asInstanceOf[QueryContext].useTableRddSink && !qb.isCTAS) {
             OperatorFactory.createSharkRddOutputPlan(hiveSinkOps.head)

--- a/src/test/scala/shark/SQLSuite.scala
+++ b/src/test/scala/shark/SQLSuite.scala
@@ -50,8 +50,8 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
     // test_null
     sc.runSql("drop table if exists test_null")
     sc.runSql("CREATE TABLE test_null (key INT, val STRING)")
-    sc.runSql("LOAD DATA LOCAL INPATH '${hiveconf:shark.test.data.path}/kv3.txt'
-               INTO TABLE test_null")
+    sc.runSql("""LOAD DATA LOCAL INPATH '${hiveconf:shark.test.data.path}/kv3.txt'
+      INTO TABLE test_null""")
     sc.runSql("drop table if exists test_null_cached")
     sc.runSql("CREATE TABLE test_null_cached AS SELECT * FROM test_null")
 

--- a/src/test/scala/shark/SQLSuite.scala
+++ b/src/test/scala/shark/SQLSuite.scala
@@ -50,7 +50,8 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
     // test_null
     sc.runSql("drop table if exists test_null")
     sc.runSql("CREATE TABLE test_null (key INT, val STRING)")
-    sc.runSql("LOAD DATA LOCAL INPATH '${hiveconf:shark.test.data.path}/kv3.txt' INTO TABLE test_null")
+    sc.runSql("LOAD DATA LOCAL INPATH '${hiveconf:shark.test.data.path}/kv3.txt'
+               INTO TABLE test_null")
     sc.runSql("drop table if exists test_null_cached")
     sc.runSql("CREATE TABLE test_null_cached AS SELECT * FROM test_null")
 
@@ -257,12 +258,21 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
     expectSql("select count(*) from foo_cached", "0")
   }
 
-  test("create cached table with table properties") {
+  test("create cached table with 'shark.cache' flag in table properties") {
     sc.runSql("drop table if exists ctas_tbl_props")
     sc.runSql("""create table ctas_tbl_props TBLPROPERTIES ('shark.cache'='true') as
       select * from test""")
     assert(SharkEnv.memoryMetadataManager.contains("ctas_tbl_props"))
     expectSql("select * from ctas_tbl_props where key=407", "407\tval_407")
+  }
+
+  test("default to Hive table creation when 'shark.cache' flag is false in table properties") {
+    sc.runSql("drop table if exists ctas_tbl_props_should_not_be_cached")
+    sc.runSql("""
+      CREATE TABLE ctas_tbl_props_result_should_not_be_cached
+        TBLPROPERTIES ('shark.cache'='false')
+        AS select * from test""")
+    assert(!SharkEnv.memoryMetadataManager.contains("ctas_tbl_props_should_not_be_cached"))
   }
 
   test("cached tables with complex types") {


### PR DESCRIPTION
Previously, the 'shark.cache' table property was used as both a boolean/flag and a cache type specification. 'shark.cache.type' is added for the latter.

This also deals with an InvalidCacheTypeException being thrown when 'shark.cache' is explicitly set to 'false'.
