### PR TITLE
Column compression cleanup

### DIFF
--- a/src/main/scala/shark/memstore2/TablePartition.scala
+++ b/src/main/scala/shark/memstore2/TablePartition.scala
@@ -60,8 +60,6 @@ class TablePartition(private var _numRows: Long, private var _columns: Array[Byt
     buffer
   }
 
-  // TODO: Add column pruning to TablePartition for creating a TablePartitionIterator.
-
   /**
    * Return an iterator for the partition.
    */
@@ -76,9 +74,9 @@ class TablePartition(private var _numRows: Long, private var _columns: Array[Byt
   def prunedIterator(columnsUsed: BitSet) = {
     val columnIterators: Array[ColumnIterator] = _columns.map {
       case buffer: ByteBuffer =>
-        val iter = ColumnIterator.newIterator(buffer)
-        iter
+        ColumnIterator.newIterator(buffer)
       case _ =>
+        // The buffer might be null if it is pruned in Tachyon.
         null
     }
     new TablePartitionIterator(_numRows, columnIterators, columnsUsed)

--- a/src/main/scala/shark/memstore2/TablePartitionIterator.scala
+++ b/src/main/scala/shark/memstore2/TablePartitionIterator.scala
@@ -17,7 +17,6 @@
 
 package shark.memstore2
 
-import java.nio.ByteBuffer
 import java.util.BitSet
 import shark.memstore2.column.ColumnIterator
 

--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -61,7 +61,7 @@ trait ColumnBuilder[T] {
     _buffer.order(ByteOrder.nativeOrder())
     _buffer.putInt(t.typeID)
   }
-  
+
   protected def growIfNeeded(orig: ByteBuffer, size: Int): ByteBuffer = {
     val capacity = orig.capacity()
     if (orig.remaining() < size) {
@@ -82,7 +82,7 @@ trait ColumnBuilder[T] {
   }
 }
 
-class DefaultColumnBuilder[T](val stats: ColumnStats[T], val t: ColumnType[T, _]) 
+class DefaultColumnBuilder[T](val stats: ColumnStats[T], val t: ColumnType[T, _])
   extends CompressedColumnBuilder[T] with NullableColumnBuilder[T]{}
 
 
@@ -105,7 +105,7 @@ trait CompressedColumnBuilder[T] extends ColumnBuilder[T] {
 
   override def build() = {
     val b = super.build()
-    
+
     if (compressionSchemes.isEmpty) {
       new NoCompression().compress(b, t)
     } else {
@@ -136,7 +136,7 @@ object ColumnBuilder {
           case PrimitiveCategory.BYTE      => new ByteColumnBuilder
           case PrimitiveCategory.TIMESTAMP => new TimestampColumnBuilder
           case PrimitiveCategory.BINARY    => new BinaryColumnBuilder
-         
+
           // TODO: add decimal column.
           case _ => throw new MemoryStoreException(
             "Invalid primitive object inspector category" + columnOi.getCategory)

--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -65,8 +65,8 @@ trait ColumnBuilder[T] {
   protected def growIfNeeded(orig: ByteBuffer, size: Int): ByteBuffer = {
     val capacity = orig.capacity()
     if (orig.remaining() < size) {
-      //grow in steps of initial size 
-      var additionalSize = capacity/8 + 1
+      // grow in steps of initial size
+      val additionalSize = capacity / 8 + 1
       var newSize = capacity + additionalSize
       if (additionalSize  < size) {
         newSize = capacity + size

--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -138,7 +138,7 @@ object ColumnBuilder {
           case PrimitiveCategory.BINARY    => new BinaryColumnBuilder
          
           // TODO: add decimal column.
-          case _ => throw new Exception(
+          case _ => throw new MemoryStoreException(
             "Invalid primitive object inspector category" + columnOi.getCategory)
         }
       }

--- a/src/main/scala/shark/memstore2/column/ColumnBuilders.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilders.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import java.nio.ByteBuffer
@@ -11,18 +28,6 @@ import org.apache.hadoop.io.Text
 import shark.execution.serialization.KryoSerializer
 import shark.memstore2.column.ColumnStats._
 
-
-class GenericColumnBuilder(oi: ObjectInspector) 
-  extends DefaultColumnBuilder[ByteStream.Output](new NoOpStats(), GENERIC) {
-
-  override def initialize(initialSize: Int):ByteBuffer = {
-    val buffer = super.initialize(initialSize)
-    val objectInspectorSerialized = KryoSerializer.serialize(oi)
-    buffer.putInt(objectInspectorSerialized.size)
-    buffer.put(objectInspectorSerialized)
-    buffer
-  }
-}
 
 class BooleanColumnBuilder extends DefaultColumnBuilder[Boolean](new BooleanColumnStats(), BOOLEAN)
 
@@ -46,3 +51,19 @@ class TimestampColumnBuilder
 class BinaryColumnBuilder extends DefaultColumnBuilder[BytesWritable](new NoOpStats(), BINARY)
 
 class VoidColumnBuilder extends DefaultColumnBuilder[Void](new NoOpStats(), VOID)
+
+/**
+ * Generic columns that we can serialize, including maps, structs, and other complex types.
+ */
+class GenericColumnBuilder(oi: ObjectInspector)
+  extends DefaultColumnBuilder[ByteStream.Output](new NoOpStats(), GENERIC) {
+
+  // Complex data types cannot be null. Override the initialize in NullableColumnBuilder.
+  override def initialize(initialSize: Int): ByteBuffer = {
+    val buffer = super.initialize(initialSize)
+    val objectInspectorSerialized = KryoSerializer.serialize(oi)
+    buffer.putInt(objectInspectorSerialized.size)
+    buffer.put(objectInspectorSerialized)
+    buffer
+  }
+}

--- a/src/main/scala/shark/memstore2/column/ColumnIterators.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterators.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import java.nio.ByteBuffer
@@ -32,9 +49,9 @@ class BinaryColumnIterator(buffer: ByteBuffer) extends DefaultColumnIterator(buf
 class StringColumnIterator(buffer: ByteBuffer) extends DefaultColumnIterator(buffer, STRING)
 
 class GenericColumnIterator(buffer: ByteBuffer) extends DefaultColumnIterator(buffer, GENERIC) {
- 
+
   private var _obj: LazyObject[_] = _
-  
+
   override def init() {
     super.init()
     val oiSize = buffer.getInt()
@@ -43,7 +60,7 @@ class GenericColumnIterator(buffer: ByteBuffer) extends DefaultColumnIterator(bu
     val oi = KryoSerializer.deserialize[ObjectInspector](oiSerialized)
     _obj = LazyFactory.createLazyObject(oi)
   }
-  
+
   override def current = {
     val v = super.current.asInstanceOf[ByteArrayRef]
     _obj.init(v, 0, v.getData().length)

--- a/src/main/scala/shark/memstore2/column/ColumnType.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnType.scala
@@ -49,9 +49,9 @@ sealed abstract class ColumnType[T : ClassManifest, V : ClassManifest](
   def writableManifest: ClassManifest[V] = classManifest[V]
 
   /**
-   * Extract a value out of the buffer.
+   * Extract a value out of the buffer at the buffer's current position.
    */
-  def extract(currentPos: Int, buffer: ByteBuffer): T
+  def extract(buffer: ByteBuffer): T
 
   /**
    * Append the given value v of type T into the given ByteBuffer.
@@ -70,10 +70,11 @@ sealed abstract class ColumnType[T : ClassManifest, V : ClassManifest](
   def actualSize(v: T): Int = defaultSize
 
   /**
-   * Extract a value out of the buffer, and put it in the writable object. This is used as an
-   * optimization to reduce the temporary objects created, since the writable object can be reused.
+   * Extract a value out of the buffer at the buffer's current position, and put it in the writable
+   * object. This is used as an optimization to reduce the temporary objects created, since the
+   * writable object can be reused.
    */
-  def extractInto(currentPos: Int, buffer: ByteBuffer, writable: V)
+  def extractInto(buffer: ByteBuffer, writable: V)
 
   /**
    * Create a new writable object corresponding to this type.
@@ -93,7 +94,7 @@ object INT extends ColumnType[Int, IntWritable](0, 4) {
     buffer.putInt(v)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     buffer.getInt()
   }
 
@@ -101,8 +102,8 @@ object INT extends ColumnType[Int, IntWritable](0, 4) {
     oi.asInstanceOf[IntObjectInspector].get(o)
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: IntWritable) {
-    writable.set(extract(currentPos, buffer))
+  override def extractInto(buffer: ByteBuffer, writable: IntWritable) {
+    writable.set(extract(buffer))
   }
 
   override def newWritable() = new IntWritable
@@ -115,7 +116,7 @@ object LONG extends ColumnType[Long, LongWritable](1, 8) {
     buffer.putLong(v)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     buffer.getLong()
   }
 
@@ -123,8 +124,8 @@ object LONG extends ColumnType[Long, LongWritable](1, 8) {
     oi.asInstanceOf[LongObjectInspector].get(o)
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: LongWritable) {
-    writable.set(extract(currentPos, buffer))
+  override def extractInto(buffer: ByteBuffer, writable: LongWritable) {
+    writable.set(extract(buffer))
   }
 
   override def newWritable() = new LongWritable
@@ -137,7 +138,7 @@ object FLOAT extends ColumnType[Float, FloatWritable](2, 4) {
     buffer.putFloat(v)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     buffer.getFloat()
   }
 
@@ -145,8 +146,8 @@ object FLOAT extends ColumnType[Float, FloatWritable](2, 4) {
     oi.asInstanceOf[FloatObjectInspector].get(o)
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: FloatWritable) {
-    writable.set(extract(currentPos, buffer))
+  override def extractInto(buffer: ByteBuffer, writable: FloatWritable) {
+    writable.set(extract(buffer))
   }
 
   override def newWritable() = new FloatWritable
@@ -159,7 +160,7 @@ object DOUBLE extends ColumnType[Double, DoubleWritable](3, 8) {
     buffer.putDouble(v)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     buffer.getDouble()
   }
 
@@ -167,8 +168,8 @@ object DOUBLE extends ColumnType[Double, DoubleWritable](3, 8) {
     oi.asInstanceOf[DoubleObjectInspector].get(o)
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: DoubleWritable) {
-    writable.set(extract(currentPos, buffer))
+  override def extractInto(buffer: ByteBuffer, writable: DoubleWritable) {
+    writable.set(extract(buffer))
   }
 
   override def newWritable() = new DoubleWritable
@@ -181,7 +182,7 @@ object BOOLEAN extends ColumnType[Boolean, BooleanWritable](4, 1) {
     buffer.put(if (v) 1.toByte else 0.toByte)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     if (buffer.get() == 1) true else false
   }
 
@@ -189,8 +190,8 @@ object BOOLEAN extends ColumnType[Boolean, BooleanWritable](4, 1) {
     oi.asInstanceOf[BooleanObjectInspector].get(o)
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: BooleanWritable) {
-    writable.set(extract(currentPos, buffer))
+  override def extractInto(buffer: ByteBuffer, writable: BooleanWritable) {
+    writable.set(extract(buffer))
   }
 
   override def newWritable() = new BooleanWritable
@@ -203,15 +204,15 @@ object BYTE extends ColumnType[Byte, ByteWritable](5, 1) {
     buffer.put(v)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     buffer.get()
   }
   override def get(o: Object, oi: ObjectInspector): Byte = {
     oi.asInstanceOf[ByteObjectInspector].get(o)
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: ByteWritable) {
-    writable.set(extract(currentPos, buffer))
+  override def extractInto(buffer: ByteBuffer, writable: ByteWritable) {
+    writable.set(extract(buffer))
   }
 
   override def newWritable() = new ByteWritable
@@ -224,7 +225,7 @@ object SHORT extends ColumnType[Short, ShortWritable](6, 2) {
     buffer.putShort(v)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     buffer.getShort()
   }
 
@@ -232,8 +233,8 @@ object SHORT extends ColumnType[Short, ShortWritable](6, 2) {
     oi.asInstanceOf[ShortObjectInspector].get(o)
   }
 
-  def extractInto(currentPos: Int, buffer: ByteBuffer, writable: ShortWritable) {
-    writable.set(extract(currentPos, buffer))
+  def extractInto(buffer: ByteBuffer, writable: ShortWritable) {
+    writable.set(extract(buffer))
   }
 
   def newWritable() = new ShortWritable
@@ -244,13 +245,13 @@ object VOID extends ColumnType[Void, NullWritable](7, 0) {
 
   override def append(v: Void, buffer: ByteBuffer) {}
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     throw new UnsupportedOperationException()
   }
 
   override def get(o: Object, oi: ObjectInspector) = null
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: NullWritable) {}
+  override def extractInto(buffer: ByteBuffer, writable: NullWritable) {}
 
   override def newWritable() = NullWritable.get
 }
@@ -276,9 +277,9 @@ object STRING extends ColumnType[Text, Text](8, 8) {
     buffer.put(v.getBytes(), 0, length)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     val t = new Text()
-    extractInto(currentPos, buffer, t)
+    extractInto(buffer, t)
     t
   }
 
@@ -288,7 +289,7 @@ object STRING extends ColumnType[Text, Text](8, 8) {
 
   override def actualSize(v: Text) = v.getLength() + 4
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: Text) {
+  override def extractInto(buffer: ByteBuffer, writable: Text) {
     val length = buffer.getInt()
     var b = _bytesFld.get(writable).asInstanceOf[Array[Byte]]
     if (b == null || b.length < length) {
@@ -316,7 +317,7 @@ object TIMESTAMP extends ColumnType[Timestamp, TimestampWritable](9, 12) {
     buffer.putInt(v.getNanos())
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     val ts = new Timestamp(0)
     ts.setTime(buffer.getLong())
     ts.setNanos(buffer.getInt())
@@ -327,8 +328,8 @@ object TIMESTAMP extends ColumnType[Timestamp, TimestampWritable](9, 12) {
     oi.asInstanceOf[TimestampObjectInspector].getPrimitiveJavaObject(o)
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: TimestampWritable) {
-    writable.set(extract(currentPos, buffer))
+  override def extractInto(buffer: ByteBuffer, writable: TimestampWritable) {
+    writable.set(extract(buffer))
   }
 
   override def newWritable() = new TimestampWritable
@@ -355,7 +356,7 @@ object BINARY extends ColumnType[BytesWritable, BytesWritable](10, 16) {
     buffer.put(v.getBytes(), 0, length)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     throw new UnsupportedOperationException()
   }
 
@@ -367,7 +368,7 @@ object BINARY extends ColumnType[BytesWritable, BytesWritable](10, 16) {
     }
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: BytesWritable) {
+  override def extractInto(buffer: ByteBuffer, writable: BytesWritable) {
     val length = buffer.getInt()
     var b = _bytesFld.get(writable).asInstanceOf[Array[Byte]]
     if (b == null || b.length < length) {
@@ -392,7 +393,7 @@ object GENERIC extends ColumnType[ByteStream.Output, ByteArrayRef](11, 16) {
     buffer.put(v.getData(), 0, length)
   }
 
-  override def extract(currentPos: Int, buffer: ByteBuffer) = {
+  override def extract(buffer: ByteBuffer) = {
     throw new UnsupportedOperationException()
   }
 
@@ -400,7 +401,7 @@ object GENERIC extends ColumnType[ByteStream.Output, ByteArrayRef](11, 16) {
     o.asInstanceOf[ByteStream.Output]
   }
 
-  override def extractInto(currentPos: Int, buffer: ByteBuffer, writable: ByteArrayRef) {
+  override def extractInto(buffer: ByteBuffer, writable: ByteArrayRef) {
     val length = buffer.getInt()
     val a = new Array[Byte](length)
     buffer.get(a, 0, length)

--- a/src/main/scala/shark/memstore2/column/ColumnType.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnType.scala
@@ -34,7 +34,19 @@ import org.apache.hadoop.io._
  * @tparam T Scala data type for the column.
  * @tparam V Writable data type for the column.
  */
-sealed abstract class ColumnType[T, V](val typeID: Int, val defaultSize: Int) {
+sealed abstract class ColumnType[T : ClassManifest, V : ClassManifest](
+    val typeID: Int, val defaultSize: Int) {
+
+  /**
+   * Scala class manifest. Can be used to create primitive arrays and hash tables.
+   */
+  def scalaManifest: ClassManifest[T] = classManifest[T]
+
+  /**
+   * Scala class manifest for the writable type. Can be used to create primitive arrays and
+   * hash tables.
+   */
+  def writableManifest: ClassManifest[V] = classManifest[V]
 
   /**
    * Extract a value out of the buffer.

--- a/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import java.nio.ByteBuffer
@@ -59,13 +76,13 @@ class DefaultDecoder[V](buffer: ByteBuffer, columnType: ColumnType[_, V]) extend
  * Run Length Decoder, decodes data compressed in RLE format of [element, length]
  */
 class RLDecoder[V](buffer: ByteBuffer, columnType: ColumnType[_, V]) extends Iterator[V] {
-  
+
   private var _run: Int = _
   private var _count: Int = 0
   private val _current: V = columnType.newWritable()
 
   override def hasNext = buffer.hasRemaining()
-  
+
   override def next(): V = {
     if (_count == _run) {
       //next run

--- a/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
@@ -49,7 +49,7 @@ class DefaultDecoder[V](buffer: ByteBuffer, columnType: ColumnType[_, V]) extend
   override def hasNext = buffer.hasRemaining()
 
   override def next(): V = {
-    columnType.extractInto(buffer.position(), buffer, _current)
+    columnType.extractInto(buffer, _current)
     _current
   }
 }
@@ -68,7 +68,7 @@ class RLDecoder[V](buffer: ByteBuffer, columnType: ColumnType[_, V]) extends Ite
   override def next(): V = {
     if (_count == _run) {
       //next run
-      columnType.extractInto(buffer.position(), buffer, _current)
+      columnType.extractInto(buffer, _current)
       _run = buffer.getInt()
       _count = 1
     } else {
@@ -91,7 +91,7 @@ class DictDecoder[V](buffer: ByteBuffer, columnType: ColumnType[_, V]) extends I
     var count = 0
     while (count < size) {
       val writable = columnType.newWritable()
-      columnType.extractInto(buffer.position(), buffer, writable)
+      columnType.extractInto(buffer, writable)
       arr(count) = writable.asInstanceOf[V]
       count += 1
     }

--- a/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
@@ -28,7 +28,8 @@ trait CompressedColumnIterator extends ColumnIterator {
     }
   }
 
-  override def computeNext() {
+  override def next() {
+    // TODO: can we remove the if branch?
     if (_decoder.hasNext) {
       _current = _decoder.next()
     }

--- a/src/main/scala/shark/memstore2/column/CompressionAlgorithm.scala
+++ b/src/main/scala/shark/memstore2/column/CompressionAlgorithm.scala
@@ -1,7 +1,7 @@
 package shark.memstore2.column
 
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
+import java.nio.{ByteBuffer, ByteOrder}
+
 import scala.annotation.tailrec
 import scala.collection.mutable.HashMap
 
@@ -12,8 +12,14 @@ trait CompressionAlgorithm  {
 
   def compressionType: CompressionType
 
+  /**
+   * Tests whether the compression algorithm supports a specific column type.
+   */
   def supportsType(t: ColumnType[_, _]): Boolean
 
+  /**
+   * Collect a value so we can update the compression ratio for this compression algorithm.
+   */
   def gatherStatsForCompressibility[T](v: T, t: ColumnType[T, _])
 
   /**
@@ -21,6 +27,9 @@ trait CompressionAlgorithm  {
    */
   def compressionRatio: Double
 
+  /**
+   * Compress the given buffer and return the compressed data as a new buffer.
+   */
   def compress[T](b: ByteBuffer, t: ColumnType[T, _]): ByteBuffer
 }
 
@@ -30,8 +39,8 @@ case class CompressionType(typeID: Int)
 object DefaultCompressionType extends CompressionType(-1)
 
 object RLECompressionType extends CompressionType(0)
+
 object DictionaryCompressionType extends CompressionType(1)
-object RLEVariantCompressionType extends CompressionType(2)
 
 
 class NoCompression extends CompressionAlgorithm {
@@ -39,7 +48,7 @@ class NoCompression extends CompressionAlgorithm {
 
   override def supportsType(t: ColumnType[_,_]) = true
 
-  override def gatherStatsForCompressibility[T](v: T, t: ColumnType[T,_]) = {}
+  override def gatherStatsForCompressibility[T](v: T, t: ColumnType[T,_]) {}
 
   override def compressionRatio: Double = 1.0
 
@@ -57,13 +66,16 @@ class NoCompression extends CompressionAlgorithm {
 }
 
 /**
- * Implements Run Length Encoding
+ * Run-length encoding for columns with a lot of repeated values.
  */
 class RLE extends CompressionAlgorithm {
-  private var _total: Int = 0
+  private var _uncompressedSize: Int = 0
+  private var _compressedSize: Int = 0
+
+  // Previous element, used to track how many runs and the run lengths.
   private var _prev: Any = _
+  // Current run length.
   private var _run: Int = 0
-  private var _size: Int = 0
 
   override def compressionType = RLECompressionType
 
@@ -74,35 +86,37 @@ class RLE extends CompressionAlgorithm {
     }
   }
 
-  override def gatherStatsForCompressibility[T](v: T, t: ColumnType[T,_]) = {
+  override def gatherStatsForCompressibility[T](v: T, t: ColumnType[T,_]) {
     val s = t.actualSize(v)
     if (_prev == null) {
+      // This is the very first run.
       _prev = t.clone(v)
       _run = 1
     } else {
       if (_prev.equals(v)) {
+        // Add one to the current run's length.
         _run += 1
       } else {
-        // flush run into size
-        _size += (t.actualSize(_prev.asInstanceOf[T]) + 4)
+        // Start a new run. Update the current run length.
+        _compressedSize += (t.actualSize(_prev.asInstanceOf[T]) + 4)
         _prev = t.clone(v)
         _run = 1
       }
     }
-    _total += s
+    _uncompressedSize += s
   }
 
   // Note that we don't actually track the size of the last run into account to simplify the
   // logic a little bit.
-  override def compressionRatio = _size / (_total + 0.0)
+  override def compressionRatio = _compressedSize / (_uncompressedSize + 0.0)
 
-  override def compress[T](b: ByteBuffer, t: ColumnType[T,_]) = {
+  override def compress[T](b: ByteBuffer, t: ColumnType[T,_]): ByteBuffer = {
     // Add the size of the last run to the _size
     if (_prev != null) {
-      _size += t.actualSize(_prev.asInstanceOf[T]) + 4
+      _compressedSize += t.actualSize(_prev.asInstanceOf[T]) + 4
     }
 
-    val compressedBuffer = ByteBuffer.allocate(_size + 4 + 4)
+    val compressedBuffer = ByteBuffer.allocate(_compressedSize + 4 + 4)
     compressedBuffer.order(ByteOrder.nativeOrder())
     compressedBuffer.putInt(b.getInt())
     compressedBuffer.putInt(compressionType.typeID)
@@ -112,7 +126,7 @@ class RLE extends CompressionAlgorithm {
   }
 
   @tailrec private final def encode[T](currentBuffer: ByteBuffer,
-    compressedBuffer: ByteBuffer, currentRun: (T, Int), t: ColumnType[T,_]) {
+      compressedBuffer: ByteBuffer, currentRun: (T, Int), t: ColumnType[T,_]) {
     def writeOutRun() {
       t.append(currentRun._1, compressedBuffer)
       compressedBuffer.putInt(currentRun._2)
@@ -137,93 +151,103 @@ class RLE extends CompressionAlgorithm {
   }
 }
 
+/**
+ * Dictionary encoding for columns with small cardinality.
+ */
 class DictionaryEncoding extends CompressionAlgorithm {
 
   private val MAX_DICT_SIZE = Short.MaxValue - 1 // 32K unique values allowed
-  private val _dictionary = new HashMap[Any, Short]()
-  private val indexSize = 2 // Short
+  private var _dictionary = new HashMap[Any, Short]()
 
-  private var _dictionarySize = 0
-  private var _totalSize = 0
+  // We use a short integer to store the dictionary index, which takes 2 bytes.
+  private val indexSize = 2
+
+  // Size of the dictionary, in bytes. Initialize the dictionary size to 4 since we use an int
+  // to store the number of elements in the dictionary.
+  private var _dictionarySize = 4
+
+  // Size of the input, uncompressed, in bytes. Note that we only count until the dictionary
+  // overflows.
+  private var _uncompressedSize = 0
+
+  // Total number of elements.
   private var _count = 0
-  private var _index: Short = 0
+
+  // If the number of distinct elements is too large, we discard the use of dictionary
+  // encoding and set the overflow flag to true.
   private var _overflow = false
 
   override def compressionType = DictionaryCompressionType
 
   override def supportsType(t: ColumnType[_, _]) = t match {
-    case STRING => true
-    case LONG => true
-    case INT => true
+    case STRING | LONG | INT => true
     case _ => false
   }
 
-  private def encode[T](v: T, t: ColumnType[T, _], sizeFunc:T => Int): Short = {
-    _count += 1
-    val size = sizeFunc(v)
-    _totalSize += size
-    if (_dictionary.size < MAX_DICT_SIZE) {
-      val s = t.clone(v)
-      _dictionary.get(s) match {
-        case Some(index) => index
-        case None => {
-          _dictionary.put(s, _index)
-          _index = (1 + _index).toShort
-          _dictionarySize += (size + indexSize)
-          _index
+  override def gatherStatsForCompressibility[T](v: T, t: ColumnType[T, _]) {
+    // Use this function to build up a dictionary.
+    if (!_overflow) {
+      val size = t.actualSize(v)
+      _count += 1
+      _uncompressedSize += size
+
+      if (!_dictionary.contains(v)) {
+        // The dictionary doesn't contain the value. Add the value to the dictionary if we haven't
+        // overflown yet.
+        if (_dictionary.size < MAX_DICT_SIZE) {
+          _dictionary.put(t.clone(v), _dictionary.size.toShort)
+          _dictionarySize += size + indexSize
+        } else {
+          // Overflown. Release the dictionary immediately to lower memory pressure.
+          _overflow = true
+          _dictionary = null
         }
       }
-    } else {
-      _overflow = true
-      -1
     }
   }
 
-  override def gatherStatsForCompressibility[T](v: T, t: ColumnType[T, _]) = {
-    //need an estimate of the # of uniques so we can build an appropriate
-    //dictionary if needed. More precisely, we only need a lower bound
-    //on # of uniques.
-    val size = t.actualSize(v)
-    encode(v, t, { _:T => size})
-  }
-
   /**
-   * return score between 0 and 1, smaller score imply higher compressibility.
-   * return Double.MaxValue to indicate overflow so that dict does not get chosen.
+   * Return the compression ratio if encoded with dictionary encoding. If the dictionary
+   * cardinality (i.e. the number of distinct elements) is bigger than 32K, we return an
+   * arbitrary number greater than 1.0.
    */
-  override def compressionRatio: Double = {
-    if (_overflow) Double.MaxValue else (bufferSize) / (_totalSize + 0.0)
+  override def compressionRatio: Double = compressedSize / (_uncompressedSize + 0.0)
+
+  private def compressedSize: Int = {
+    // Total compressed size =
+    //   size of the dictionary +
+    //   the number of elements * dictionary encoded size (short) +
+    //   an integer for compression type
+    //   an integer for column type
+    if (_overflow) Int.MaxValue else _dictionarySize + _count * indexSize + 4 + 4
   }
 
-  private def writeDictionary[T](compressedBuffer: ByteBuffer, t: ColumnType[T, _]) {
-    //store dictionary size
+  override def compress[T](b: ByteBuffer, t: ColumnType[T, _]): ByteBuffer = {
+    if (_overflow) {
+      throw new MemoryStoreException(
+        "Dictionary encoding should not be used because we have overflown the dictionary.")
+    }
+
+    // Create a new buffer and store the compression type and column type.
+    val compressedBuffer = ByteBuffer.allocate(compressedSize)
+    compressedBuffer.order(ByteOrder.nativeOrder())
+    compressedBuffer.putInt(b.getInt())
+    compressedBuffer.putInt(compressionType.typeID)
+
+    // Write out the dictionary.
     compressedBuffer.putInt(_dictionary.size)
-    //store the dictionary
     _dictionary.foreach { x =>
       t.append(x._1.asInstanceOf[T], compressedBuffer)
       compressedBuffer.putShort(x._2)
     }
-  }
 
-  private def dictionarySize = _dictionarySize + 4
-  private def bufferSize = { _count*indexSize + dictionarySize + 4 + 4 }
-
-  override def compress[T](b: ByteBuffer, t: ColumnType[T, _]): ByteBuffer = {
-    //build a dictionary of given size
-    val compressedBuffer = ByteBuffer.allocate(bufferSize)
-    compressedBuffer.order(ByteOrder.nativeOrder())
-    compressedBuffer.putInt(b.getInt())
-    compressedBuffer.putInt(compressionType.typeID)
-    //store dictionary size
-    writeDictionary(compressedBuffer, t)
-    //traverse the original buffer
+    // Write out the encoded values, each is represented by a short integer.
     while (b.hasRemaining()) {
       val v = t.extract(b.position(), b)
-      _dictionary.get(v).map { index =>
-        compressedBuffer.putShort(index)
-      }
-      
+      compressedBuffer.putShort(_dictionary(v))
     }
+
+    // Rewind the compressed buffer and return it.
     compressedBuffer.rewind()
     compressedBuffer
   }

--- a/src/main/scala/shark/memstore2/column/CompressionAlgorithm.scala
+++ b/src/main/scala/shark/memstore2/column/CompressionAlgorithm.scala
@@ -135,7 +135,7 @@ class RLE extends CompressionAlgorithm {
       writeOutRun()
       return
     }
-    val elem = t.extract(currentBuffer.position(), currentBuffer)
+    val elem = t.extract(currentBuffer)
     val newRun =
       if (currentRun == null) {
         (elem, 1)
@@ -252,7 +252,7 @@ class DictionaryEncoding extends CompressionAlgorithm {
 
     // Write out the encoded values, each is represented by a short integer.
     while (b.hasRemaining()) {
-      val v = t.extract(b.position(), b)
+      val v = t.extract(b)
       compressedBuffer.putShort(_dictionary(v))
     }
 

--- a/src/main/scala/shark/memstore2/column/MemoryStoreException.scala
+++ b/src/main/scala/shark/memstore2/column/MemoryStoreException.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.memstore2.column
+
+
+class MemoryStoreException(message: String) extends Exception(message)

--- a/src/main/scala/shark/memstore2/column/NullableColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/NullableColumnBuilder.scala
@@ -7,19 +7,20 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 
 
 /**
- * Builds a nullable column. The byte buffer of a nullable column contains
- * the column type, followed by the null count and the index of nulls, followed
- * finally by the non nulls.
+ * Builds a nullable column. The byte buffer of a nullable column contains:
+ * - 4 bytes for the null count (number of nulls)
+ * - positions for each null, in ascending order
+ * - the non-null data (column data type, compression type, data...)
  */
 trait NullableColumnBuilder[T] extends ColumnBuilder[T] {
 
   private var _nulls: ByteBuffer = _
   
   private var _pos: Int = _
-  private var _nullCount:Int = _
+  private var _nullCount: Int = _
 
   override def initialize(initialSize: Int): ByteBuffer = {
-    _nulls =  ByteBuffer.allocate(1024)
+    _nulls = ByteBuffer.allocate(1024)
     _nulls.order(ByteOrder.nativeOrder())
     _pos = 0
     _nullCount = 0
@@ -38,19 +39,16 @@ trait NullableColumnBuilder[T] extends ColumnBuilder[T] {
   }
 
   override def build(): ByteBuffer = {
-    val b = super.build()
-    if (_pos == 0) {
-      b
-    } else {
-      val v = _nulls.position()
-      _nulls.limit(v)
-      _nulls.rewind()
-      val newBuffer = ByteBuffer.allocate(b.limit + v + 4)
-      newBuffer.order(ByteOrder.nativeOrder())
-      val colType= b.getInt()
-      newBuffer.putInt(colType).putInt(_nullCount).put(_nulls).put(b)
-      newBuffer.rewind()
-      newBuffer
-    }
+    val nonNulls = super.build()
+    val nullDataLen = _nulls.position()
+    _nulls.limit(nullDataLen)
+    _nulls.rewind()
+
+    // 4 bytes for null count + null positions + non nulls
+    val newBuffer = ByteBuffer.allocate(4 + nullDataLen + nonNulls.limit)
+    newBuffer.order(ByteOrder.nativeOrder())
+    newBuffer.putInt(_nullCount).put(_nulls).put(nonNulls)
+    newBuffer.rewind()
+    newBuffer
   }
 }

--- a/src/main/scala/shark/memstore2/column/NullableColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/NullableColumnBuilder.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import java.nio.ByteBuffer
@@ -15,7 +32,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 trait NullableColumnBuilder[T] extends ColumnBuilder[T] {
 
   private var _nulls: ByteBuffer = _
-  
+
   private var _pos: Int = _
   private var _nullCount: Int = _
 

--- a/src/main/scala/shark/memstore2/column/NullableColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/NullableColumnIterator.scala
@@ -15,7 +15,7 @@ class NullableColumnIterator(delegate: ColumnIterator, buffer: ByteBuffer) exten
   private var _nulls = 0
 
   private var _isNull = false
-  private var _currentNullIndex:Int = _
+  private var _currentNullIndex: Int = _
   private var _pos = 0
 
   override def init() {
@@ -42,15 +42,7 @@ class NullableColumnIterator(delegate: ColumnIterator, buffer: ByteBuffer) exten
     _pos += 1
   }
   
-  override def hasNext: Boolean = {
-    if (_nulls < _nullCount) {
-      true
-    } else {
-      delegate.hasNext
-    }
-  }
+  override def hasNext: Boolean = (_nulls < _nullCount) || delegate.hasNext
 
-  def current: Object = {
-    if (_isNull) null else delegate.current
-  }
+  def current: Object = if (_isNull) null else delegate.current
 }

--- a/src/main/scala/shark/memstore2/column/NullableColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/NullableColumnIterator.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import java.nio.ByteBuffer
@@ -45,7 +62,7 @@ class NullableColumnIterator(buffer: ByteBuffer) extends ColumnIterator {
     }
     _pos += 1
   }
-  
+
   override def hasNext: Boolean = (_nulls < _nullCount) || _delegate.hasNext
 
   def current: Object = if (_isNull) null else _delegate.current

--- a/src/test/scala/shark/memstore2/column/ColumnTypeSuite.scala
+++ b/src/test/scala/shark/memstore2/column/ColumnTypeSuite.scala
@@ -15,7 +15,7 @@ class ColumnTypeSuite extends FunSuite {
     a.foreach {i => buffer.putInt(i)}
     buffer.rewind()
     a.foreach {i => 
-      val v = INT.extract(buffer.position(), buffer)
+      val v = INT.extract(buffer)
       assert(v == i)
     }
     buffer = ByteBuffer.allocate(32)
@@ -32,7 +32,7 @@ class ColumnTypeSuite extends FunSuite {
     buffer.rewind()
     val writable = new IntWritable()
     a.foreach { i => 
-      INT.extractInto(buffer.position(), buffer, writable)
+      INT.extractInto(buffer, writable)
       assert(writable.get == i)
     }
     
@@ -46,7 +46,7 @@ class ColumnTypeSuite extends FunSuite {
     a.foreach {i => buffer.putShort(i)}
     buffer.rewind()
     a.foreach {i => 
-      val v = SHORT.extract(buffer.position(), buffer)
+      val v = SHORT.extract(buffer)
       assert(v == i)
     }
     
@@ -64,7 +64,7 @@ class ColumnTypeSuite extends FunSuite {
     buffer.rewind()
     val writable = new ShortWritable()
     a.foreach { i => 
-      SHORT.extractInto(buffer.position(), buffer, writable)
+      SHORT.extractInto(buffer, writable)
       assert(writable.get == i)
     }
   }
@@ -77,7 +77,7 @@ class ColumnTypeSuite extends FunSuite {
     a.foreach {i => buffer.putLong(i)}
     buffer.rewind()
     a.foreach {i => 
-      val v = LONG.extract(buffer.position(), buffer)
+      val v = LONG.extract(buffer)
       assert(v == i)
     }
     
@@ -95,7 +95,7 @@ class ColumnTypeSuite extends FunSuite {
     buffer.rewind()
     val writable = new LongWritable()
     a.foreach { i => 
-      LONG.extractInto(buffer.position(), buffer, writable)
+      LONG.extractInto(buffer, writable)
       assert(writable.get == i)
     }
   }

--- a/src/test/scala/shark/memstore2/column/ColumnTypeSuite.scala
+++ b/src/test/scala/shark/memstore2/column/ColumnTypeSuite.scala
@@ -1,10 +1,29 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
-import org.scalatest.FunSuite
 import java.nio.ByteBuffer
+
 import org.apache.hadoop.io.IntWritable
 import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.hive.serde2.io._
+
+import org.scalatest.FunSuite
 
 class ColumnTypeSuite extends FunSuite {
 
@@ -14,30 +33,30 @@ class ColumnTypeSuite extends FunSuite {
     var a: Seq[Int] = Array[Int](35, 67, 899, 4569001)
     a.foreach {i => buffer.putInt(i)}
     buffer.rewind()
-    a.foreach {i => 
+    a.foreach {i =>
       val v = INT.extract(buffer)
       assert(v == i)
     }
     buffer = ByteBuffer.allocate(32)
     a = Range(0, 4)
-    a.foreach { i => 
-      INT.append(i, buffer)  
+    a.foreach { i =>
+      INT.append(i, buffer)
     }
     buffer.rewind()
     a.foreach { i => assert(buffer.getInt() == i)}
-    
+
     buffer = ByteBuffer.allocate(32)
     a =Range(0,4)
     a.foreach { i => buffer.putInt(i)}
     buffer.rewind()
     val writable = new IntWritable()
-    a.foreach { i => 
+    a.foreach { i =>
       INT.extractInto(buffer, writable)
       assert(writable.get == i)
     }
-    
+
   }
-  
+
   test("Short") {
     assert(SHORT.defaultSize == 2)
     assert(SHORT.actualSize(8) == 2)
@@ -45,30 +64,30 @@ class ColumnTypeSuite extends FunSuite {
     var a = Array[Short](35, 67, 87, 45)
     a.foreach {i => buffer.putShort(i)}
     buffer.rewind()
-    a.foreach {i => 
+    a.foreach {i =>
       val v = SHORT.extract(buffer)
       assert(v == i)
     }
-    
+
     buffer = ByteBuffer.allocate(32)
     a = Array[Short](0,1,2,3)
-    a.foreach { i => 
-      SHORT.append(i, buffer)  
+    a.foreach { i =>
+      SHORT.append(i, buffer)
     }
     buffer.rewind()
     a.foreach { i => assert(buffer.getShort() == i)}
-    
+
     buffer = ByteBuffer.allocate(32)
     a =Array[Short](0,1,2,3)
     a.foreach { i => buffer.putShort(i)}
     buffer.rewind()
     val writable = new ShortWritable()
-    a.foreach { i => 
+    a.foreach { i =>
       SHORT.extractInto(buffer, writable)
       assert(writable.get == i)
     }
   }
-  
+
   test("Long") {
     assert(LONG.defaultSize == 8)
     assert(LONG.actualSize(45L) == 8)
@@ -76,25 +95,25 @@ class ColumnTypeSuite extends FunSuite {
     var a = Array[Long](35L, 67L, 8799000880L, 45000999090L)
     a.foreach {i => buffer.putLong(i)}
     buffer.rewind()
-    a.foreach {i => 
+    a.foreach {i =>
       val v = LONG.extract(buffer)
       assert(v == i)
     }
-    
+
     buffer = ByteBuffer.allocate(32)
     a = Array[Long](0,1,2,3)
-    a.foreach { i => 
-      LONG.append(i, buffer)  
+    a.foreach { i =>
+      LONG.append(i, buffer)
     }
     buffer.rewind()
     a.foreach { i => assert(buffer.getLong() == i)}
-    
+
     buffer = ByteBuffer.allocate(32)
     a =Array[Long](0,1,2,3)
     a.foreach { i => buffer.putLong(i)}
     buffer.rewind()
     val writable = new LongWritable()
-    a.foreach { i => 
+    a.foreach { i =>
       LONG.extractInto(buffer, writable)
       assert(writable.get == i)
     }

--- a/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
@@ -13,7 +13,13 @@ import shark.memstore2.column.Implicits._
 class CompressedColumnIteratorSuite extends FunSuite {
 
   /**
-   * Generic tester across types and encodings
+   * Generic tester across types and encodings. The function applies the given compression
+   * algorithm on the given sequence of values, and test whether the resulting iterator gives
+   * the same sequence of values.
+   *
+   * If we expect the compression algorithm to not compress the data, we should set the
+   * shouldNotCompress flag to true. This way, it doesn't actually create a compressed buffer,
+   * but simply tests the compression ratio returned by the algorithm is >= 1.0.
    */
   def testList[T, W](
       l: Seq[T],

--- a/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
@@ -12,117 +12,110 @@ import shark.memstore2.column.Implicits._
 
 class CompressedColumnIteratorSuite extends FunSuite {
 
-  val booleanList = Array[Boolean](true, true, false, true)
-  val byteList = Array[Byte](10, 10, 20, 10)
-  val shortList = byteList.map { i => (Short.MaxValue - i).toShort }
-  val iList = byteList.map { i => Int.MaxValue - i.toInt }
-  val lList = iList.map { i => Long.MaxValue - i.toLong }
-  val sList = iList.map { i => new Text(i.toString) }
-
-  /** Generic tester across types and encodings
-    *
-    */
+  /**
+   * Generic tester across types and encodings
+   */
   def testList[T, W](
-    l: Seq[T],
-    u: ColumnType[T, _],
-    algo: CompressionAlgorithm,
-    compareFunc: (T, T) => Boolean = (a: T, b: T) => a == b,
-    shouldNotCompress: Boolean = false) {
-
-    val b = ByteBuffer.allocate(1024 + (3*40*l.size))
+      l: Seq[T],
+      t: ColumnType[T, _],
+      algo: CompressionAlgorithm,
+      compareFunc: (T, T) => Boolean = (a: T, b: T) => a == b,
+      shouldNotCompress: Boolean = false)
+  {
+    val b = ByteBuffer.allocate(1024 + (3 * 40 * l.size))
     b.order(ByteOrder.nativeOrder())
-    b.putInt(u.typeID)
+    b.putInt(t.typeID)
     l.foreach { item =>
-      u.append(item.asInstanceOf[T], b)
-      algo.gatherStatsForCompressibility(item, u.asInstanceOf[ColumnType[Any, _]])
+      t.append(item, b)
+      algo.gatherStatsForCompressibility(item, t.asInstanceOf[ColumnType[Any, _]])
     }
     b.limit(b.position())
     b.rewind()
-    val compressedBuffer = algo.compress(b, u)
+
     if (shouldNotCompress) {
       assert(algo.compressionRatio >= 1.0)
-      info("CompressionRatio " + algo.compressionRatio)
     } else {
-
+      val compressedBuffer = algo.compress(b, t)
       val iter = new TestIterator(compressedBuffer, compressedBuffer.getInt())
 
-      val oi: ObjectInspector = u match {
+      val oi: ObjectInspector = t match {
         case BOOLEAN => PrimitiveObjectInspectorFactory.writableBooleanObjectInspector
         case BYTE    => PrimitiveObjectInspectorFactory.writableByteObjectInspector
         case SHORT   => PrimitiveObjectInspectorFactory.writableShortObjectInspector
         case INT     => PrimitiveObjectInspectorFactory.writableIntObjectInspector
         case LONG    => PrimitiveObjectInspectorFactory.writableLongObjectInspector
         case STRING  => PrimitiveObjectInspectorFactory.writableStringObjectInspector
+        case _       => throw new UnsupportedOperationException("Unsupported compression type " + t)
       }
 
       l.foreach { x =>
         iter.next()
-        assert(compareFunc(u.get(iter.current, oi), x))
-        // assert(u.get(iter.current, oi) === x)
+        assert(compareFunc(t.get(iter.current, oi), x))
       }
-      assert(false === iter.hasNext) // no extras at the end
+
+      // Make sure we reach the end of the iterator.
+      assert(!iter.hasNext)
     }
   }
 
-  test("RLE Decompression Boolean") {
-    testList(booleanList, BOOLEAN, new RLE())
+  test("RLE Boolean") {
+    testList(Seq[Boolean](true, true, false, true), BOOLEAN, new RLE())
   }
 
-  test("RLE Decompression Byte") {
-    testList(byteList, BYTE, new RLE())
+  test("RLE Byte") {
+    testList(Seq[Byte](10, 10, 20, 10), BYTE, new RLE())
   }
 
-  test("RLE Decompression Short") {
-    testList(shortList, SHORT, new RLE())
+  test("RLE Short") {
+    testList(Seq[Short](10, 10, 10, 20000, 20000, 20000, 500, 500, 500, 500), SHORT, new RLE())
   }
 
-  test("RLE Decompression Int") {
-    testList(iList, INT, new RLE())
+  test("RLE Int") {
+    testList(Seq[Int](1000000, 1000000, 1000000, 1000000, 900000, 99), INT, new RLE())
   }
 
-  test("RLE Decompression Long") {
-    testList(lList, LONG, new RLE())
+  test("RLE Long") {
+    val longs = Seq[Long](2147483649L, 2147483649L, 2147483649L, 2147483649L, 500L, 500L, 500L)
+    testList(longs, LONG, new RLE())
   }
 
-  test("RLE Decompression String") {
-    testList(sList, STRING, new RLE(), (a: Text, b: Text) => a.hashCode == b.hashCode)
+  test("RLE String") {
+    val strs: Seq[Text] = Seq("abcd", "abcd", "abcd", "e", "e", "!", "!").map(s => new Text(s))
+    testList(strs, STRING, new RLE(), (a: Text, b: Text) => a.equals(b))
   }
 
-  test("Dictionary Decompression Int") {
-    testList(iList, INT, new DictionaryEncoding())
+  test("Dictionary Encoded Int") {
+    testList(Seq[Int](1000000, 1000000, 1000000, 1000000, 900000, 99), INT, new DictionaryEncoding)
   }
 
-  test("Dictionary Decompression Long") {
-    testList(lList, LONG, new DictionaryEncoding())
+  test("Dictionary Encoded Long") {
+    val longs = Seq[Long](2147483649L, 2147483649L, 2147483649L, 2147483649L, 500L, 500L, 500L)
+    testList(longs, LONG, new DictionaryEncoding)
   }
 
-  test("Dictionary Decompression String") {
-    testList(sList, STRING, new DictionaryEncoding(), (a: Text, b: Text) => a.hashCode == b.hashCode)
+  test("Dictionary Encoded String") {
+    val strs: Seq[Text] = Seq("abcd", "abcd", "abcd", "e", "e", "!", "!").map(s => new Text(s))
+    testList(strs, STRING, new DictionaryEncoding, (a: Text, b: Text) => a.equals(b),
+      shouldNotCompress = false)
   }
 
-  test("Dictionary Decompression at limit of unique values") {
-    val alternating = Range(0, Short.MaxValue-1, 1).flatMap { s => List(1, s) }
-    val iiList = byteList.map { i => i.toInt }
-    val hugeList = List.concat(iiList, alternating, iiList)
-    assert(hugeList.size === (8 + 2*(Short.MaxValue-1)))
-    testList(hugeList, INT, new DictionaryEncoding())
+  test("Dictionary Encoding at limit of unique values") {
+    val ints = Range(0, Short.MaxValue - 1).flatMap(i => Iterator(i, i, i))
+    testList(ints, INT, new DictionaryEncoding)
   }
 
-  test("Dictionary Decompression - should not compress") {
-    val alternating = Range(0, Short.MaxValue-1, 1).flatMap { s => List(1, s) }
-    val hugeList = List.concat(iList, alternating, iList)
-    assert(hugeList.size === (8 + 2*(Short.MaxValue-1)))
-    testList(hugeList, INT, new DictionaryEncoding(), (a: Int, b: Int) => a == b, true)
+  test("Dictionary Encoding - should not compress") {
+    val ints = Range(0, Short.MaxValue.toInt)
+    testList(ints, INT, new DictionaryEncoding, (a: Int, b: Int) => a == b,
+      shouldNotCompress = true)
   }
 
   test("RLE - should not compress") {
-    val alternating = Range(0, Short.MaxValue-1, 1).flatMap { s => List(1, s) }
-    val hugeList = List.concat(iList, alternating, iList)
-    assert(hugeList.size === (8 + 2*(Short.MaxValue-1)))
-    testList(hugeList, INT, new RLE(), (a: Int, b: Int) => a == b, true)
+    val ints = Range(0, Short.MaxValue.toInt + 1)
+    testList(ints, INT, new RLE, (a: Int, b: Int) => a == b, shouldNotCompress = true)
   }
-
 }
 
- class TestIterator(val buffer: ByteBuffer, val columnType: ColumnType[_,_])
-      extends CompressedColumnIterator
+
+class TestIterator(val buffer: ByteBuffer, val columnType: ColumnType[_,_])
+    extends CompressedColumnIterator

--- a/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
@@ -55,11 +55,11 @@ class CompressionAlgorithmSuite extends FunSuite {
     val compressedBuffer = rle.compress(b, STRING)
     assert(compressedBuffer.getInt() == STRING.typeID)
     assert(compressedBuffer.getInt() == RLECompressionType.typeID)
-    assert(STRING.extract(compressedBuffer.position(), compressedBuffer).equals(new Text("abc")))
+    assert(STRING.extract(compressedBuffer).equals(new Text("abc")))
     assert(compressedBuffer.getInt() == 2)
-    assert(STRING.extract(compressedBuffer.position(), compressedBuffer).equals(new Text("efg")))
+    assert(STRING.extract(compressedBuffer).equals(new Text("efg")))
     assert(compressedBuffer.getInt() == 1)
-    assert(STRING.extract(compressedBuffer.position(), compressedBuffer).equals(new Text("abc")))
+    assert(STRING.extract(compressedBuffer).equals(new Text("abc")))
     assert(compressedBuffer.getInt() == 1)
     assert(!compressedBuffer.hasRemaining)
   }
@@ -194,7 +194,7 @@ class CompressionAlgorithmSuite extends FunSuite {
       val dictionary = new HashMap[Short, T]()
       var count = 0
       while (count < expectedDictSize) {
-        val v = u.extract(compressedBuffer.position(), compressedBuffer)
+        val v = u.extract(compressedBuffer)
         dictionary.put(dictionary.size.toShort, u.clone(v))
         count += 1
       }

--- a/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
@@ -221,23 +221,24 @@ class CompressionAlgorithmSuite extends FunSuite {
     testList(longList, INT, Short.MaxValue - 1)
   }
   
-  test("RLE region") {
+  test("Uncompressed text") {
     val b = new StringColumnBuilder
     b.initialize(0)
     val oi = PrimitiveObjectInspectorFactory.javaStringObjectInspector
 
-    val lines = Array[String]("lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to",
+    val lines = Array[String](
+      "lar deposits. blithely final packages cajole. regular waters are final requests.",
       "hs use ironic, even requests. s",
       "ges. thinly even pinto beans ca",
       "ly final courts cajole furiously final excuse",
-      "uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl"
+      "uickly special accounts cajole carefully blithely close requests. carefully final"
     )
     lines.foreach { line =>
       b.append(line, oi)
     }
     val newBuffer = b.build()
-    assert(newBuffer.getInt() == STRING.typeID)
-    assert(newBuffer.getInt() == RLECompressionType.typeID)
-    
+    assert(newBuffer.getInt() === 0)  // null count
+    assert(newBuffer.getInt() === STRING.typeID)
+    assert(newBuffer.getInt() === DefaultCompressionType.typeID)
   }
 }

--- a/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import java.nio.{ByteBuffer, ByteOrder}
@@ -84,7 +101,7 @@ class CompressionAlgorithmSuite extends FunSuite {
     assert(compressedBuffer.getInt() == 1)
     assert(!compressedBuffer.hasRemaining)
   }
-  
+
   test("RLE int single run") {
     val b = ByteBuffer.allocate(4008)
     b.order(ByteOrder.nativeOrder())
@@ -103,7 +120,7 @@ class CompressionAlgorithmSuite extends FunSuite {
     assert(compressedBuffer.getInt() == 1000)
     assert(!compressedBuffer.hasRemaining)
   }
-  
+
   test("RLE long single run") {
     val b = ByteBuffer.allocate(8008)
     b.order(ByteOrder.nativeOrder())
@@ -122,7 +139,7 @@ class CompressionAlgorithmSuite extends FunSuite {
     assert(compressedBuffer.getInt() == 1000)
     assert(!compressedBuffer.hasRemaining)
   }
-  
+
   test("RLE int 3 runs") {
     val b = ByteBuffer.allocate(4008)
     b.order(ByteOrder.nativeOrder())
@@ -168,7 +185,7 @@ class CompressionAlgorithmSuite extends FunSuite {
     assert(compressedBuffer.getInt() == 1000000)
     assert(!compressedBuffer.hasRemaining)
   }
-  
+
   test("Dictionary Encoding") {
 
     def testList[T](
@@ -200,7 +217,7 @@ class CompressionAlgorithmSuite extends FunSuite {
       }
       assert(dictionary.get(0).get.equals(l(0)))
       assert(dictionary.get(1).get.equals(l(2)))
-      l.foreach { x => 
+      l.foreach { x =>
         val y = dictionary.get(compressedBuffer.getShort()).get
         assert(compareFunc(y, x))
       }
@@ -220,7 +237,7 @@ class CompressionAlgorithmSuite extends FunSuite {
     assert(longList.size === (8 + 2*(Short.MaxValue-1)))
     testList(longList, INT, Short.MaxValue - 1)
   }
-  
+
   test("Uncompressed text") {
     val b = new StringColumnBuilder
     b.initialize(0)

--- a/src/test/scala/shark/memstore2/column/NullableColumnBuilderSuite.scala
+++ b/src/test/scala/shark/memstore2/column/NullableColumnBuilderSuite.scala
@@ -1,25 +1,22 @@
 package shark.memstore2.column
 
-import org.scalatest.FunSuite
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
 
+import org.scalatest.FunSuite
 
 class NullableColumnBuilderSuite extends FunSuite {
 
-  test("Perf") {
-    val c = new StringColumnBuilder()
-    c.initialize(1024*1024*8)
-    val oi = PrimitiveObjectInspectorFactory.writableStringObjectInspector
-    Range(0, 1000000).foreach { i =>
-      c.append(new Text("00000000000000000000000000000000" + i), oi)
-    }
+  test("Empty column") {
+    val c = new IntColumnBuilder()
+    c.initialize(4)
     val b = c.build()
-    val i = ColumnIterator.newIterator(b)
-    Range(0, 1000000).foreach { x =>
-      i.next()
-      i.current
-    }
+    // # of nulls
+    assert(b.getInt() === 0)
+    // column type
+    assert(b.getInt() === INT.typeID)
+    assert(b.getInt() === DefaultCompressionType.typeID)
+    assert(!b.hasRemaining)
   }
 
   test("Buffer size auto growth") {
@@ -35,8 +32,9 @@ class NullableColumnBuilderSuite extends FunSuite {
     c.append(null, oi)
     c.append(new Text("efg"), oi)
     val b = c.build()
+    b.position(4 + 4 * 4)
     val colType = b.getInt()
-    assert(colType == STRING.typeID)
+    assert(colType === STRING.typeID)
   }
 
   test("Null Strings") {
@@ -48,22 +46,27 @@ class NullableColumnBuilderSuite extends FunSuite {
     c.append(new Text("b"), oi)
     c.append(null, oi)
     val b = c.build()
-    //expect first element is col type
-    assert(b.getInt() == STRING.typeID)
-    //next comes # of nulls
-    assert(b.getInt() == 2)
-    //typeID of first null is 1, that of second null is 3
-    assert(b.getInt() == 1)
-    assert(b.getInt() == 3)
+
+    // Number of nulls
+    assert(b.getInt() === 2)
+
+    // First null position is 1, and then 3
+    assert(b.getInt() === 1)
+    assert(b.getInt() === 3)
+
+    // Column data type
+    assert(b.getInt() === STRING.typeID)
    
-    //next comes the compression type
-    assert(b.getInt() == -1)
-    assert(b.getInt() == 1)
-    assert(b.get() == 97)
-    assert(b.getInt() == 1)
-    assert(b.get() == 98)
+    // Compression type
+    assert(b.getInt() === DefaultCompressionType.typeID)
+
+    // Data
+    assert(b.getInt() === 1)
+    assert(b.get() === 97)
+    assert(b.getInt() === 1)
+    assert(b.get() === 98)
   }
-  
+
   test("Null Ints") {
     val c = new IntColumnBuilder()
     c.initialize(4)
@@ -73,17 +76,34 @@ class NullableColumnBuilderSuite extends FunSuite {
     c.append(null, oi)
     c.append(56.asInstanceOf[Object], oi)
     val b = c.build()
-    //expect first element is col type
-    assert(b.getInt() == INT.typeID)
-    //next comes # of nulls
-    assert(b.getInt() == 2)
-    //typeID of first null is 1, that of second null is 3
-    assert(b.getInt() == 1)
-    assert(b.getInt() == 2)
-    assert(b.getInt() == -1)
-    assert(b.getInt() == 123)
+
+    // # of nulls and null positions
+    assert(b.getInt() === 2)
+    assert(b.getInt() === 1)
+    assert(b.getInt() === 2)
+
+    // non nulls
+    assert(b.getInt() === INT.typeID)
+    assert(b.getInt() === DefaultCompressionType.typeID)
+    assert(b.getInt() === 123)
   }
-  
+
+  test("Nullable Ints 2") {
+    val c = new IntColumnBuilder()
+    c.initialize(4)
+    val oi = PrimitiveObjectInspectorFactory.javaIntObjectInspector
+    Range(1, 1000).foreach { x =>
+      c.append(x.asInstanceOf[Object], oi)
+    }
+    val b = c.build()
+    // null count
+    assert(b.getInt() === 0)
+    // column type
+    assert(b.getInt() === INT.typeID)
+    // compression type
+    assert(b.getInt() === DefaultCompressionType.typeID)
+  }
+
   test("Null Longs") {
     val c = new LongColumnBuilder()
     c.initialize(4)
@@ -93,26 +113,16 @@ class NullableColumnBuilderSuite extends FunSuite {
     c.append(null, oi)
     c.append(56L.asInstanceOf[Object], oi)
     val b = c.build()
-    //expect first element is col type
-    assert(b.getInt() == LONG.typeID)
-    //next comes # of nulls
-    assert(b.getInt() == 2)
-    //typeID of first null is 1, that of second null is 3
-    assert(b.getInt() == 1)
-    assert(b.getInt() == 2)
-    assert(b.getInt() == -1)
-    assert(b.getLong() == 123L)
+
+    // # of nulls and null positions
+    assert(b.getInt() === 2)
+    assert(b.getInt() === 1)
+    assert(b.getInt() === 2)
+
+    // non-nulls
+    assert(b.getInt() === LONG.typeID)
+    assert(b.getInt() === DefaultCompressionType.typeID)
+    assert(b.getLong() === 123L)
   }
-  
-  test("Trigger RLE") {
-    val c = new IntColumnBuilder()
-    c.initialize(4)
-    val oi = PrimitiveObjectInspectorFactory.javaIntObjectInspector
-    Range(1, 1000).foreach { x =>
-      c.append(x.asInstanceOf[Object], oi)
-    }
-    val b = c.build()
-    assert(b.getInt() == INT.typeID)
-    assert(b.getInt() == RLECompressionType.typeID)
-  }
+
 }

--- a/src/test/scala/shark/memstore2/column/NullableColumnBuilderSuite.scala
+++ b/src/test/scala/shark/memstore2/column/NullableColumnBuilderSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import org.apache.hadoop.io.Text
@@ -56,7 +73,7 @@ class NullableColumnBuilderSuite extends FunSuite {
 
     // Column data type
     assert(b.getInt() === STRING.typeID)
-   
+
     // Compression type
     assert(b.getInt() === DefaultCompressionType.typeID)
 

--- a/src/test/scala/shark/memstore2/column/NullableColumnBuilderSuite.scala
+++ b/src/test/scala/shark/memstore2/column/NullableColumnBuilderSuite.scala
@@ -22,7 +22,7 @@ class NullableColumnBuilderSuite extends FunSuite {
     }
   }
 
-  test("Grow") {
+  test("Buffer size auto growth") {
     val c = new StringColumnBuilder()
     c.initialize(4)
     val oi = PrimitiveObjectInspectorFactory.writableStringObjectInspector
@@ -108,7 +108,7 @@ class NullableColumnBuilderSuite extends FunSuite {
     val c = new IntColumnBuilder()
     c.initialize(4)
     val oi = PrimitiveObjectInspectorFactory.javaIntObjectInspector
-    Range(1,1000).foreach { x =>
+    Range(1, 1000).foreach { x =>
       c.append(x.asInstanceOf[Object], oi)
     }
     val b = c.build()

--- a/src/test/scala/shark/memstore2/column/NullableColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/column/NullableColumnIteratorSuite.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package shark.memstore2.column
 
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
@@ -63,7 +80,7 @@ class NullableColumnIteratorSuite extends FunSuite {
     assert(i.current == null)
     assert(false === i.hasNext)
   }
-  
+
   test("Iterate Ints") {
     def testList(l: Seq[AnyRef]) {
       val oi = PrimitiveObjectInspectorFactory.javaIntObjectInspector

--- a/src/test/scala/shark/memstore2/column/NullableColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/column/NullableColumnIteratorSuite.scala
@@ -25,7 +25,7 @@ class NullableColumnIteratorSuite extends FunSuite {
     val b = c.build()
     val i = ColumnIterator.newIterator(b)
     Range(0, a.length).foreach { x =>
-      if (x > 0) assert(true === i.hasNext)
+      if (x > 0) assert(i.hasNext)
       i.next()
       val v = i.current
       if (a(x) == null) {
@@ -34,7 +34,7 @@ class NullableColumnIteratorSuite extends FunSuite {
         assert(v.toString == a(x).toString)
       }
     }
-    assert(false === i.hasNext)
+    assert(!i.hasNext)
   }
 
   test("Iterate Strings") {
@@ -71,7 +71,7 @@ class NullableColumnIteratorSuite extends FunSuite {
       c.initialize(l.size)
 
       l.foreach { item =>
-        c.append(item.asInstanceOf[AnyRef], oi)
+        c.append(item, oi)
       }
 
       val b = c.build()

--- a/src/test/scala/shark/util/BloomFilterSuite.scala
+++ b/src/test/scala/shark/util/BloomFilterSuite.scala
@@ -5,13 +5,13 @@ import org.scalatest.FunSuite
 class BloomFilterSuite extends FunSuite{
 
   test("Integer") {
-    val bf = new BloomFilter(0.03,1000000)
-    Range(0,1000000).foreach {
+    val bf = new BloomFilter(0.03, 1000000)
+    Range(0, 1000000).foreach {
       i => bf.add(i)
     }
     assert(bf.contains(333))
     assert(bf.contains(678))
-    assert(bf.contains(1200000) == false)
+    assert(!bf.contains(1200000))
   }
   
   test("Integer FP") {
@@ -26,12 +26,10 @@ class BloomFilterSuite extends FunSuite{
       i => bf.contains(i*10)
     }
     val s = e.groupBy(x => x).map(x => (x._1, x._2.size))
-    println(s)
     val t = s(true)
     val f = s(false)
     assert(f > 25 && f < 35)
     assert(t < 75 && t > 65)
     // expect false positive to be < 3 % and no false negatives
-    
   }
 }


### PR DESCRIPTION
- In dictionary encoding, the dictionary itself doesn't need to store the index (the values are stored in order of the index)
- In dictionary encoding decoder, uses an array to replace the original hash table so dictionary lookup is always O(1)
- Remove the position argument for extract/extractInfo methods in ColumnType
- init() is called in a ColumnIterator's constructor, and removed computeNext()
- Corrected various tests. Some tests were testing for the wrong thing (e.g. a few tests used null count for compression type ...)
- Various other minor changes to improve code readability and test readability
