### PR TITLE
Fix name for non assembly jar.

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -118,7 +118,6 @@ object SharkBuild extends Build {
   )
 
   def assemblyProjSettings = Seq(
-    name := "shark-assembly",
     jarName in assembly <<= version map { v => "shark-assembly-" + v + "-hadoop" + HADOOP_VERSION + ".jar" }
   ) ++ assemblySettings ++ extraAssemblySettings
 


### PR DESCRIPTION
Fix the name for non-assembly jar. Tweak of jarName is adequate for the fat jar.
