### PR TITLE
Pull the Hadoop version from the environment.

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -32,7 +32,13 @@ object SharkBuild extends Build {
 
   // Hadoop version to build against. For example, "0.20.2", "0.20.205.0", or
   // "1.0.1" for Apache releases, or "0.20.2-cdh3u3" for Cloudera Hadoop.
-  val HADOOP_VERSION = "1.0.4"
+  val DEFAULT_HADOOP_VERSION = "1.0.4"
+
+  import scala.util.Properties.{ envOrNone => env }
+  lazy val hadoopVersion = env("SHARK_HADOOP_VERSION") orElse
+                           env("SPARK_HADOOP_VERSION") getOrElse
+                           DEFAULT_HADOOP_VERSION
+
 
   // Whether to build Shark with Tachyon jar.
   val TACHYON_ENABLED = false
@@ -103,7 +109,7 @@ object SharkBuild extends Build {
       "org.apache.spark" %% "spark-core" % SPARK_VERSION,
       "org.apache.spark" %% "spark-repl" % SPARK_VERSION,
       "com.google.guava" % "guava" % "14.0.1",
-      "org.apache.hadoop" % "hadoop-client" % HADOOP_VERSION excludeAll(excludeJackson, excludeNetty, excludeAsm),
+      "org.apache.hadoop" % "hadoop-client" % hadoopVersion excludeAll(excludeJackson, excludeNetty, excludeAsm),
       // See https://code.google.com/p/guava-libraries/issues/detail?id=1095
       "com.google.code.findbugs" % "jsr305" % "1.3.+",
 
@@ -121,7 +127,7 @@ object SharkBuild extends Build {
   )
 
   def assemblyProjSettings = Seq(
-    jarName in assembly <<= version map { v => "shark-assembly-" + v + "-hadoop" + HADOOP_VERSION + ".jar" }
+    jarName in assembly <<= version map { v => "shark-assembly-" + v + "-hadoop" + hadoopVersion + ".jar" }
   ) ++ assemblySettings ++ extraAssemblySettings
 
   def extraAssemblySettings() = Seq(


### PR DESCRIPTION
This introduces two environment variables that you can use to control
the version of Hadoop that you build against. The Spark project
uses `SPARK_HADOOP_VERSION`, which is supported. By analogy, we
also support `SHARK_HADOOP_VERSION`, which has precedence over
`SPARK_HADOOP_VERSION`. If neither of these environment variables are
set at build time, the defaults from the build script are used.

The algorithm looks like this:
1. Use `SHARK_HADOOP_VERSION` if set.
2. Use `SPARK_HADOOP_VERSION` if set.
3. Use the default that is hard-coded into the build definition.
