### PR TITLE
Took log4j init out of SharkContext.

### DIFF
--- a/src/main/scala/shark/SharkContext.scala
+++ b/src/main/scala/shark/SharkContext.scala
@@ -24,8 +24,6 @@ import scala.collection.Map
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.hive.conf.HiveConf
-import org.apache.hadoop.hive.common.LogUtils
-import org.apache.hadoop.hive.common.LogUtils.LogInitializationException
 import org.apache.hadoop.hive.ql.Driver
 import org.apache.hadoop.hive.ql.processors.CommandProcessor
 import org.apache.hadoop.hive.ql.processors.CommandProcessorFactory
@@ -178,12 +176,6 @@ object SharkContext {
 
   @transient val hiveconf = new HiveConf(classOf[SessionState])
   Utils.setAwsCredentials(hiveconf)
-
-  try {
-    LogUtils.initHiveLog4j()
-  } catch {
-    case e: LogInitializationException => // Ignore the error.
-  }
 
   @transient val sessionState = new SessionState(hiveconf)
   sessionState.out = new PrintStream(System.out, true, "UTF-8")

--- a/src/main/scala/shark/repl/Main.scala
+++ b/src/main/scala/shark/repl/Main.scala
@@ -17,10 +17,20 @@
 
 package shark.repl
 
+import org.apache.hadoop.hive.common.LogUtils
+import org.apache.hadoop.hive.common.LogUtils.LogInitializationException
+
+
 /**
  * Shark's REPL entry point.
  */
 object Main {
+
+  try {
+    LogUtils.initHiveLog4j()
+  } catch {
+    case e: LogInitializationException => // Ignore the error.
+  }
 
   private var _interp: SharkILoop = null
 


### PR DESCRIPTION
This way, applications that use SharkContext can properly initialize their own log4j configuration.
