### PR TITLE
SHARK-183: implementing BooleanBitSetCompression

### DIFF
--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -145,7 +145,7 @@ object ColumnBuilder {
       case _ => new GenericColumnBuilder(columnOi)
     }
     if (shouldCompress) {
-      v.compressionSchemes = Seq(new RLE())
+      v.compressionSchemes = Seq(new RLE(), new BooleanBitSetCompression())
     }
     v
   }

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -53,6 +53,7 @@ object Implicits {
     case DefaultCompressionType.typeID => DefaultCompressionType
     case RLECompressionType.typeID => RLECompressionType
     case DictionaryCompressionType.typeID => DictionaryCompressionType
+    case BooleanBitSetCompressionType.typeID => BooleanBitSetCompressionType
     case _ => throw new MemoryStoreException("Unknown compression type " + i)
   }
 

--- a/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
@@ -153,6 +153,22 @@ class CompressedColumnIteratorSuite extends FunSuite {
     val expectedLen = (Short.MaxValue.toInt + 1) * (4 + 4)
     testList(ints, INT, new RLE, expectedLen, shouldNotCompress = true)
   }
+
+  test("BooleanBitSet Boolean (shorter)") {
+    // 1 Long worth of Booleans, in addtion to the length field: 4+8
+    val bools = Seq(true, true, false, false)
+    testList(bools, BOOLEAN, new BooleanBitSetCompression, 4+8)
+  }
+
+  test("BooleanBitSet Boolean (longer)") {
+    // 2 Longs worth of Booleans, in addtion to the length field: 4+8+8
+    val bools = Seq(true, true, false, false, true, true, false, false,true, true, false, false,true, true, false, false,
+      true, true, false, false,true, true, false, false, true, true, false, false,true, true, false, false,
+      true, true, false, false,true, true, false, false, true, true, false, false,true, true, false, false,
+      true, true, false, false,true, true, false, false, true, true, false, false,true, true, false, false,
+      true, true, false, false,true, true, false, false, true, true, false, false,true, true, false, false)
+    testList(bools, BOOLEAN, new BooleanBitSetCompression, 4+8+8)
+  }
 }
 
 

--- a/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
@@ -258,4 +258,34 @@ class CompressionAlgorithmSuite extends FunSuite {
     assert(newBuffer.getInt() === STRING.typeID)
     assert(newBuffer.getInt() === DefaultCompressionType.typeID)
   }
+
+  test("BooleanBitSet encoding") {
+    val bbs = new BooleanBitSetCompression()
+    val b = ByteBuffer.allocate(4 + 64 + 2)
+    b.order(ByteOrder.nativeOrder())
+    b.putInt(BOOLEAN.typeID)
+    for(_ <- 1 to 5) {
+      b.put(0.toByte)
+      b.put(1.toByte)
+      bbs.gatherStatsForCompressibility(false, BOOLEAN)
+      bbs.gatherStatsForCompressibility(true, BOOLEAN)
+    }
+    for(_ <- 1 to 54) {
+      b.put(0.toByte)
+      bbs.gatherStatsForCompressibility(false, BOOLEAN)
+    }
+    b.put(0.toByte)
+    b.put(1.toByte)
+    bbs.gatherStatsForCompressibility(false, BOOLEAN)
+    bbs.gatherStatsForCompressibility(true, BOOLEAN)
+    b.limit(b.position())
+    b.rewind()
+    val compressedBuffer = bbs.compress(b, BOOLEAN)
+    assert(compressedBuffer.getInt() === BOOLEAN.typeID)
+    assert(compressedBuffer.getInt() === BooleanBitSetCompressionType.typeID)
+    assert(compressedBuffer.getInt() === 64 + 2)
+    assert(compressedBuffer.getLong() === 682)
+    assert(compressedBuffer.getLong() === 2)
+    assert(!compressedBuffer.hasRemaining)
+  }
 }


### PR DESCRIPTION
Added an encoder for Booleans into Bytes to the Memstore that uses the CompressionAlgorithm API. Thanks Reynold for help and discussion.
