### PR TITLE
Add a SparkDDLTask for handling Shark-specific metastore operations.

### DIFF
--- a/src/main/scala/shark/SharkDriver.scala
+++ b/src/main/scala/shark/SharkDriver.scala
@@ -35,7 +35,8 @@ import org.apache.hadoop.util.StringUtils
 
 import shark.api.TableRDD
 import shark.api.QueryExecutionException
-import shark.execution.{SharkExplainTask, SharkExplainWork, SparkTask, SparkWork}
+import shark.execution.{SparkDDLTask, SparkDDLWork, SharkExplainTask, SharkExplainWork, SparkTask,
+  SparkWork}
 import shark.memstore2.ColumnarSerDe
 import shark.parse.{QueryContext, SharkSemanticAnalyzerFactory}
 
@@ -62,6 +63,7 @@ private[shark] object SharkDriver extends LogHelper {
 
   // Task factory. Add Shark specific tasks.
   TaskFactory.taskvec.addAll(Seq(
+    new TaskFactory.taskTuple(classOf[SparkDDLWork], classOf[SparkDDLTask]),
     new TaskFactory.taskTuple(classOf[SparkWork], classOf[SparkTask]),
     new TaskFactory.taskTuple(classOf[SharkExplainWork], classOf[SharkExplainTask])))
 

--- a/src/main/scala/shark/execution/SparkDDLTask.scala
+++ b/src/main/scala/shark/execution/SparkDDLTask.scala
@@ -57,9 +57,11 @@ private[shark] class SparkDDLTask extends HiveTask[SparkDDLWork] with Serializab
   def alterTable(
       hiveMetadataDb: Hive,
       alterTableDesc: AlterTableDesc) {
-    val oldName = alterTableDesc.getOldName
-    val newName = alterTableDesc.getNewName
-    SharkEnv.memoryMetadataManager.rename(oldName, newName)
+    if (alterTableDesc.getOp() == AlterTableDesc.AlterTableTypes.RENAME) {
+      val oldName = alterTableDesc.getOldName
+      val newName = alterTableDesc.getNewName
+      SharkEnv.memoryMetadataManager.rename(oldName, newName)
+    }
   }
 
   override def getType = StageType.DDL

--- a/src/main/scala/shark/execution/SparkDDLTask.scala
+++ b/src/main/scala/shark/execution/SparkDDLTask.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.execution
+
+import scala.collection.JavaConversions._
+
+import org.apache.hadoop.hive.ql.{Context, DriverContext}
+import org.apache.hadoop.hive.ql.exec.{Task => HiveTask, TaskExecutionException}
+import org.apache.hadoop.hive.ql.metadata.Hive
+import org.apache.hadoop.hive.ql.plan._
+import org.apache.hadoop.hive.ql.plan.api.StageType
+
+import shark.{LogHelper, SharkEnv}
+import shark.memstore2.{CacheType, MemoryMetadataManager}
+
+
+private[shark] class SparkDDLWork(val ddlDesc: DDLDesc) extends java.io.Serializable {
+  // Used only for CREATE TABLE.
+  var cacheMode: CacheType.CacheType = _
+}
+
+private[shark] class SparkDDLTask extends HiveTask[SparkDDLWork] with Serializable with LogHelper {
+
+  override def execute(driverContext: DriverContext): Int = {
+    val hiveMetadataDb = Hive.get(conf)
+
+    work.ddlDesc match {
+      case alterTableDesc: AlterTableDesc => {
+        alterTable(hiveMetadataDb, alterTableDesc)
+      }
+      case _ => {
+        throw new UnsupportedOperationException(
+          "Shark does not require a Spark DDL task for: " + work.ddlDesc.getClass.getName)
+      }
+    }
+
+    // Hive's task runner expects a '0' return value to indicate success and exceptions on
+    // failure.
+    return 0
+  }
+
+  def alterTable(
+      hiveMetadataDb: Hive,
+      alterTableDesc: AlterTableDesc) {
+    val oldName = alterTableDesc.getOldName
+    val newName = alterTableDesc.getNewName
+    SharkEnv.memoryMetadataManager.rename(oldName, newName)
+  }
+
+  override def getType = StageType.DDL
+
+  override def getName = "DDL-SPARK"
+
+  override def localizeMRTmpFilesImpl(ctx: Context) = Unit
+}

--- a/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
+++ b/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
@@ -52,6 +52,19 @@ class MemoryMetadataManager {
     _keyToStats.get(key.toLowerCase)
   }
 
+  def rename(oldKey: String, newKey: String) {
+    if (contains(oldKey)) {
+      val oldKeyToLowerCase = oldKey.toLowerCase
+      val newKeyToLowerCase = newKey.toLowerCase
+
+      val statsValueEntry = _keyToStats.remove(oldKeyToLowerCase).get
+      val rddValueEntry = _keyToRdd.remove(oldKeyToLowerCase).get
+
+      _keyToStats.put(newKeyToLowerCase, statsValueEntry)
+      _keyToRdd.put(newKeyToLowerCase, rddValueEntry)
+    }
+  }
+
   /**
    * Find all keys that are strings. Used to drop tables after exiting.
    */

--- a/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
@@ -20,6 +20,9 @@ class SharkDDLSemanticAnalyzer(conf: HiveConf) extends DDLSemanticAnalyzer(conf)
     super.analyzeInternal(astNode)
 
     astNode.getToken.getType match {
+      case HiveParser.TOK_DROPTABLE => {
+        SharkEnv.unpersist(getTableName(astNode))
+      }
       case HiveParser.TOK_ALTERTABLE_RENAME => {
         analyzeAlterTableRename(astNode)
       }

--- a/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
@@ -1,21 +1,47 @@
 package shark.parse
 
+import scala.collection.JavaConversions._
+
 import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.ql.exec.TaskFactory
 import org.apache.hadoop.hive.ql.parse.{ASTNode, BaseSemanticAnalyzer, DDLSemanticAnalyzer, HiveParser}
+import org.apache.hadoop.hive.ql.plan.DDLWork
 
 import org.apache.spark.rdd.{UnionRDD, RDD}
 
+import shark.execution.SparkDDLWork
 import shark.{LogHelper, SharkEnv}
+import shark.memstore2.MemoryMetadataManager
 
 
 class SharkDDLSemanticAnalyzer(conf: HiveConf) extends DDLSemanticAnalyzer(conf) with LogHelper {
 
-  override def analyzeInternal(node: ASTNode): Unit = {
-    super.analyzeInternal(node)
-    //handle drop table query
-    if (node.getToken().getType() == HiveParser.TOK_DROPTABLE) {
-      SharkEnv.unpersist(getTableName(node))
+  override def analyzeInternal(astNode: ASTNode): Unit = {
+    super.analyzeInternal(astNode)
+
+    astNode.getToken.getType match {
+      case HiveParser.TOK_ALTERTABLE_RENAME => {
+        analyzeAlterTableRename(astNode)
+      }
+      case _ => Unit
     }
+  }
+
+  private def analyzeAlterTableRename(astNode: ASTNode) {
+    val oldTableName = getTableName(astNode)
+    val newTableName = BaseSemanticAnalyzer.getUnescapedName(
+      astNode.getChild(1).asInstanceOf[ASTNode])
+
+    // Hive's DDLSemanticAnalyzer#AnalyzeInternal() will only populate rootTasks with a DDLTask
+    // and DDLWork that contains an AlterTableDesc.
+    assert(rootTasks.size == 1)
+    val ddlTask = rootTasks.head
+    val ddlWork = ddlTask.getWork
+    assert(ddlWork.isInstanceOf[DDLWork])
+
+    val alterTableDesc = ddlWork.asInstanceOf[DDLWork].getAlterTblDesc
+    val sparkDDLWork = new SparkDDLWork(alterTableDesc)
+    ddlTask.addDependentTask(TaskFactory.get(sparkDDLWork, conf))
   }
 
   private def getTableName(node: ASTNode): String = {

--- a/src/test/scala/shark/SQLSuite.scala
+++ b/src/test/scala/shark/SQLSuite.scala
@@ -222,6 +222,16 @@ class SQLSuite extends FunSuite with BeforeAndAfterAll {
   //////////////////////////////////////////////////////////////////////////////
   // cache DDL
   //////////////////////////////////////////////////////////////////////////////
+  test("rename cached table") {
+    sc.runSql("drop table if exists test_oldname_cached")
+    sc.runSql("drop table if exists test_rename")
+    sc.runSql("create table test_oldname_cached as select * from test")
+    sc.runSql("alter table test_oldname_cached rename to test_rename")
+    assert(!SharkEnv.memoryMetadataManager.contains("test_oldname_cached"))
+    assert(SharkEnv.memoryMetadataManager.contains("test_rename"))
+    expectSql("select count(*) from test_rename", "500")
+  }
+
   test("insert into cached tables") {
     sc.runSql("drop table if exists test1_cached")
     sc.runSql("create table test1_cached as select * from test")


### PR DESCRIPTION
Includes support for ALTER TABLE <old naem> RENAME TO <new name> on cached tables.

Currently, this is meant to be a dependent task on Hive's DDLTask.
