### PR TITLE
SparkDDLTask(Work) => SharkDDLTask(Work)

### DIFF
--- a/src/main/scala/shark/SharkDriver.scala
+++ b/src/main/scala/shark/SharkDriver.scala
@@ -35,7 +35,7 @@ import org.apache.hadoop.util.StringUtils
 
 import shark.api.TableRDD
 import shark.api.QueryExecutionException
-import shark.execution.{SparkDDLTask, SparkDDLWork, SharkExplainTask, SharkExplainWork, SparkTask,
+import shark.execution.{SharkDDLTask, SharkDDLWork, SharkExplainTask, SharkExplainWork, SparkTask,
   SparkWork}
 import shark.memstore2.ColumnarSerDe
 import shark.parse.{QueryContext, SharkSemanticAnalyzerFactory}
@@ -63,7 +63,7 @@ private[shark] object SharkDriver extends LogHelper {
 
   // Task factory. Add Shark specific tasks.
   TaskFactory.taskvec.addAll(Seq(
-    new TaskFactory.taskTuple(classOf[SparkDDLWork], classOf[SparkDDLTask]),
+    new TaskFactory.taskTuple(classOf[SharkDDLWork], classOf[SharkDDLTask]),
     new TaskFactory.taskTuple(classOf[SparkWork], classOf[SparkTask]),
     new TaskFactory.taskTuple(classOf[SharkExplainWork], classOf[SharkExplainTask])))
 

--- a/src/main/scala/shark/execution/SharkDDLTask.scala
+++ b/src/main/scala/shark/execution/SharkDDLTask.scala
@@ -29,12 +29,12 @@ import shark.{LogHelper, SharkEnv}
 import shark.memstore2.{CacheType, MemoryMetadataManager}
 
 
-private[shark] class SparkDDLWork(val ddlDesc: DDLDesc) extends java.io.Serializable {
+private[shark] class SharkDDLWork(val ddlDesc: DDLDesc) extends java.io.Serializable {
   // Used only for CREATE TABLE.
   var cacheMode: CacheType.CacheType = _
 }
 
-private[shark] class SparkDDLTask extends HiveTask[SparkDDLWork] with Serializable with LogHelper {
+private[shark] class SharkDDLTask extends HiveTask[SharkDDLWork] with Serializable with LogHelper {
 
   override def execute(driverContext: DriverContext): Int = {
     val hiveMetadataDb = Hive.get(conf)

--- a/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
@@ -9,7 +9,7 @@ import org.apache.hadoop.hive.ql.plan.DDLWork
 
 import org.apache.spark.rdd.{UnionRDD, RDD}
 
-import shark.execution.SparkDDLWork
+import shark.execution.SharkDDLWork
 import shark.{LogHelper, SharkEnv}
 import shark.memstore2.MemoryMetadataManager
 
@@ -44,8 +44,8 @@ class SharkDDLSemanticAnalyzer(conf: HiveConf) extends DDLSemanticAnalyzer(conf)
       assert(ddlWork.isInstanceOf[DDLWork])
 
       val alterTableDesc = ddlWork.asInstanceOf[DDLWork].getAlterTblDesc
-      val sparkDDLWork = new SparkDDLWork(alterTableDesc)
-      ddlTask.addDependentTask(TaskFactory.get(sparkDDLWork, conf))
+      val sharkDDLWork = new SharkDDLWork(alterTableDesc)
+      ddlTask.addDependentTask(TaskFactory.get(sharkDDLWork, conf))
     }
   }
 


### PR DESCRIPTION
Rename SparkDDLTask to SharkDDLTask, since no Spark jobs are submitted during task execution.
