### PR TITLE
Revert to using RDD#collect() for map joins,

### DIFF
--- a/src/main/scala/shark/execution/MapJoinOperator.scala
+++ b/src/main/scala/shark/execution/MapJoinOperator.scala
@@ -28,9 +28,7 @@ import org.apache.hadoop.hive.ql.exec.{MapJoinOperator => HiveMapJoinOperator}
 import org.apache.hadoop.hive.ql.plan.MapJoinDesc
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 
-import org.apache.spark.SparkEnv
 import org.apache.spark.rdd.RDD
-import org.apache.spark.storage.StorageLevel
 
 import shark.SharkEnv
 import shark.execution.serialization.{OperatorSerializationWrapper, SerializableWritable}
@@ -114,6 +112,7 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
       // following mapParititons will fail because it tries to include the
       // outer closure, which references "this".
       val op = op1
+      // An RDD of (Join key, Corresponding rows) tuples.
       val rddForHash: RDD[(Seq[AnyRef], Seq[Array[AnyRef]])] =
         rdd.mapPartitions { partition =>
           op.initializeOnSlave()
@@ -125,28 +124,15 @@ class MapJoinOperator extends CommonJoinOperator[MapJoinDesc, HiveMapJoinOperato
 
       // Collect the RDD and build a hash table.
       val startCollect = System.currentTimeMillis()
-      val storageLevel = rddForHash.getStorageLevel
-      if(storageLevel == StorageLevel.NONE)
-        rddForHash.persist(StorageLevel.MEMORY_AND_DISK)
-      rddForHash.foreach(_ => Unit)
-      val wrappedRows = rddForHash.partitions.flatMap { part =>
-        val blockId = "rdd_%s_%s".format(rddForHash.id, part.index)
-        val iter = SparkEnv.get.blockManager.get(blockId)
-        val partRows = new ArrayBuffer[(Seq[AnyRef], Seq[Array[AnyRef]])]
-        iter.foreach(_.foreach { row =>
-          partRows += row.asInstanceOf[(Seq[AnyRef], Seq[Array[AnyRef]])]
-        })
-        partRows
-      }
-      if(storageLevel == StorageLevel.NONE)
-        rddForHash.unpersist()
 
-      logDebug("wrappedRows size:" + wrappedRows.size)
+      val collectedRows: Array[(Seq[AnyRef], Seq[Array[AnyRef]])] = rddForHash.collect()
+
+      logDebug("collectedRows size:" + collectedRows.size)
       val collectTime = System.currentTimeMillis() - startCollect
       logInfo("HashTable collect took " + collectTime + " ms")
 
       // Build the hash table.
-      val hash = wrappedRows.groupBy(x => x._1)
+      val hash = collectedRows.groupBy(x => x._1)
        .mapValues(v => v.flatMap(t => t._2))
 
       val map = new JHashMap[Seq[AnyRef], Array[Array[AnyRef]]]()

--- a/src/main/scala/shark/execution/ReduceKey.scala
+++ b/src/main/scala/shark/execution/ReduceKey.scala
@@ -79,7 +79,8 @@ class ReduceKeyMapSide(var bytesWritable: BytesWritable) extends ReduceKey
         if (length != other.length) {
           false
         } else {
-          WritableComparator.compareBytes(byteArray, 0, length, other.byteArray, 0, other.length) == 0
+          WritableComparator.compareBytes(
+            byteArray, 0, length, other.byteArray, 0, other.length) == 0
         }
       }
       case _ => false
@@ -116,10 +117,12 @@ class ReduceKeyReduceSide(private val _byteArray: Array[Byte]) extends ReduceKey
   override def length: Int = byteArray.length
 
   override def equals(other: Any): Boolean = {
-    // We expect this is only used in a hash table comparing to the same types.
-    // So we force a type cast.
-    val that = other.asInstanceOf[ReduceKeyReduceSide]
-    (this.byteArray.length == that.byteArray.length && this.compareTo(that) == 0)
+    other match {
+      case that: ReduceKeyReduceSide => {
+        (this.byteArray.length == that.byteArray.length) && (this.compareTo(that) == 0)
+      }
+      case _ => false
+    }
   }
 
   override def compareTo(that: ReduceKey): Int = {


### PR DESCRIPTION
Since Spark can send Task results through the block manager when the Akka frame size is exceeded.

Notes:
- Includes patch from https://github.com/amplab/shark/pull/188, which fixes a group-by bug.
- Reverts Shark PR from https://github.com/amplab/shark/pull/98
- Relevant commit on the Spark side: https://github.com/apache/incubator-spark/commit/c75eb14fe52f6789430983471974e5ddf73aacbf
