### PR TITLE
Get Shark to compile with latest Spark master.

### DIFF
--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -85,9 +85,6 @@ object SharkEnv extends LogHelper {
 
   logDebug("Initializing SharkEnv")
 
-  System.setProperty("spark.serializer", classOf[SparkKryoSerializer].getName)
-  System.setProperty("spark.kryo.registrator", classOf[KryoRegistrator].getName)
-
   val executorEnvVars = new HashMap[String, String]
   executorEnvVars.put("SCALA_HOME", getEnv("SCALA_HOME"))
   executorEnvVars.put("SPARK_MEM", getEnv("SPARK_MEM"))

--- a/src/main/scala/shark/execution/CoGroupedRDD.scala
+++ b/src/main/scala/shark/execution/CoGroupedRDD.scala
@@ -122,7 +122,7 @@ class CoGroupedRDD[K](@transient var rdds: Seq[RDD[(_, _)]], part: Partitioner)
         // Read map outputs of shuffle
         def mergePair(pair: (K, Any)) { getSeq(pair._1)(depNum) += pair._2 }
         val fetcher = SparkEnv.get.shuffleFetcher
-        fetcher.fetch[(K, Seq[Any])](shuffleId, split.index, context.taskMetrics, serializer)
+        fetcher.fetch[(K, Seq[Any])](shuffleId, split.index, context, serializer)
           .foreach(mergePair)
       }
     }

--- a/src/main/scala/shark/execution/FileSinkOperator.scala
+++ b/src/main/scala/shark/execution/FileSinkOperator.scala
@@ -73,6 +73,7 @@ class FileSinkOperator extends TerminalOperator with Serializable {
 
     iter.foreach { row =>
       numRows += 1
+      // Process and writes each row to a temp file.
       localHiveOp.processOp(row, 0)
     }
 
@@ -112,7 +113,7 @@ class FileSinkOperator extends TerminalOperator with Serializable {
       }
     }
 
-    localHiveOp.closeOp(false)
+    localHiveOp.closeOp(false /* abort */)
     Iterator(numRows)
   }
 
@@ -181,7 +182,7 @@ class FileSinkOperator extends TerminalOperator with Serializable {
         logDebug("Total number of rows written: " + rows.sum)
     }
 
-    hiveOp.jobClose(localHconf, true, new JobCloseFeedBack)
+    hiveOp.jobClose(localHconf, true /* success */, new JobCloseFeedBack)
     rdd
   }
 }


### PR DESCRIPTION
This seems to be the only change, after relaxing access constraints on TaskContext's stageId here: https://github.com/apache/incubator-spark/pull/62

Also included removing Kryo registration, since Shark uses its ShuffleSerializer for serializing objects during shuffles. This also fixes an earlier issue with mapjoin serialization here: https://github.com/amplab/shark/pull/187
