### PR TITLE
 Handle database namespaces for cached tables

### DIFF
--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -114,7 +114,8 @@ object SharkEnv extends LogHelper {
   val addedFiles = HashSet[String]()
   val addedJars = HashSet[String]()
 
-  def unpersist(key: String): Option[RDD[_]] = {
+  def unpersist(databaseName: String, tableName: String): Option[RDD[_]] = {
+    val key = databaseName + '.' + tableName
     if (SharkEnv.tachyonUtil.tachyonEnabled() && SharkEnv.tachyonUtil.tableExists(key)) {
       if (SharkEnv.tachyonUtil.dropTable(key)) {
         logInfo("Table " + key + " was deleted from Tachyon.");
@@ -123,7 +124,7 @@ object SharkEnv extends LogHelper {
       }
     }
 
-    memoryMetadataManager.unpersist(key)
+    memoryMetadataManager.unpersist(databaseName, tableName)
   }
 
   /** Cleans up and shuts down the Shark environments. */

--- a/src/main/scala/shark/execution/OperatorFactory.scala
+++ b/src/main/scala/shark/execution/OperatorFactory.scala
@@ -45,6 +45,7 @@ object OperatorFactory extends LogHelper {
   def createSharkMemoryStoreOutputPlan(
       hiveTerminalOp: HiveOperator,
       tableName: String,
+      databaseName: String,
       storageLevel: StorageLevel,
       numColumns: Int,
       useTachyon: Boolean,
@@ -52,6 +53,7 @@ object OperatorFactory extends LogHelper {
     val sinkOp = _newOperatorInstance(
       classOf[MemoryStoreSinkOperator], hiveTerminalOp).asInstanceOf[MemoryStoreSinkOperator]
     sinkOp.tableName = tableName
+    sinkOp.databaseName = databaseName
     sinkOp.storageLevel = storageLevel
     sinkOp.numColumns = numColumns
     sinkOp.useTachyon = useTachyon

--- a/src/main/scala/shark/execution/SharkDDLTask.scala
+++ b/src/main/scala/shark/execution/SharkDDLTask.scala
@@ -60,7 +60,7 @@ private[shark] class SharkDDLTask extends HiveTask[SharkDDLWork] with Serializab
     if (alterTableDesc.getOp() == AlterTableDesc.AlterTableTypes.RENAME) {
       val oldName = alterTableDesc.getOldName
       val newName = alterTableDesc.getNewName
-      SharkEnv.memoryMetadataManager.rename(oldName, newName)
+      SharkEnv.memoryMetadataManager.rename(hiveMetadataDb.getCurrentDatabase(), oldName, newName)
     }
   }
 

--- a/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
+++ b/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
@@ -40,23 +40,33 @@ class MemoryMetadataManager {
   private val _keyToStats: ConcurrentMap[String, collection.Map[Int, TablePartitionStats]] =
     new ConcurrentHashMap[String, collection.Map[Int, TablePartitionStats]]
 
-  def contains(key: String) = _keyToRdd.contains(key.toLowerCase)
+  def contains(databaseName: String, tableName: String) = {
+    val key = databaseName + '.' + tableName
+    _keyToRdd.contains(key.toLowerCase)
+  }
 
-  def put(key: String, rdd: RDD[_]) {
+  def put(databaseName: String, tableName: String, rdd: RDD[_]) {
+    val key = databaseName + '.' + tableName
     _keyToRdd(key.toLowerCase) = rdd
   }
 
-  def get(key: String): Option[RDD[_]] = _keyToRdd.get(key.toLowerCase)
+  def get(databaseName: String, tableName: String): Option[RDD[_]] = {
+    val key = databaseName + '.' + tableName
+    _keyToRdd.get(key.toLowerCase) 
+  }
 
-  def putStats(key: String, stats: collection.Map[Int, TablePartitionStats]) {
+  def putStats(databaseName: String, tableName: String, stats: collection.Map[Int, TablePartitionStats]) {
+    val key = databaseName + '.' + tableName
     _keyToStats.put(key.toLowerCase, stats)
   }
 
-  def getStats(key: String): Option[collection.Map[Int, TablePartitionStats]] = {
+  def getStats(databaseName: String, tableName: String): Option[collection.Map[Int, TablePartitionStats]] = {
+    val key = databaseName + '.' + tableName
     _keyToStats.get(key.toLowerCase)
   }
 
-  def getNextPartNum(key: String): Int = {
+  def getNextPartNum(databaseName: String, tableName: String): Int = {
+    val key = databaseName + '.' + tableName
     val currentPartNum = _keyToNextPart.get(key.toLowerCase)
     currentPartNum match {
       case Some(partNum) => {
@@ -70,8 +80,11 @@ class MemoryMetadataManager {
     }
   }
 
-  def rename(oldKey: String, newKey: String) {
-    if (contains(oldKey)) {
+  def rename(databaseName: String, oldTableName: String, newTableName: String) {
+    val oldKey = databaseName + '.' + oldTableName
+    val newKey = databaseName + '.' + newTableName
+
+    if (contains(databaseName, oldTableName)) {
       val oldKeyToLowerCase = oldKey.toLowerCase
       val newKeyToLowerCase = newKey.toLowerCase
 
@@ -98,7 +111,8 @@ class MemoryMetadataManager {
    * @return Option::isEmpty() is true if there is no RDD value corresponding to 'key' in
    *         '_keyToRDD'. Otherwise, returns a reference to the RDD that was unpersist()'ed.
    */
-  def unpersist(key: String): Option[RDD[_]] = {
+  def unpersist(databaseName: String, tableName: String): Option[RDD[_]] = {
+    val key = databaseName + '.' + tableName
     def unpersistRDD(rdd: RDD[_]): Unit = {
       rdd match {
         case u: UnionRDD[_] => {

--- a/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkDDLSemanticAnalyzer.scala
@@ -21,7 +21,7 @@ class SharkDDLSemanticAnalyzer(conf: HiveConf) extends DDLSemanticAnalyzer(conf)
 
     astNode.getToken.getType match {
       case HiveParser.TOK_DROPTABLE => {
-        SharkEnv.unpersist(getTableName(astNode))
+        SharkEnv.unpersist(db.getCurrentDatabase(), getTableName(astNode))
       }
       case HiveParser.TOK_ALTERTABLE_RENAME => {
         analyzeAlterTableRename(astNode)
@@ -32,7 +32,7 @@ class SharkDDLSemanticAnalyzer(conf: HiveConf) extends DDLSemanticAnalyzer(conf)
 
   private def analyzeAlterTableRename(astNode: ASTNode) {
     val oldTableName = getTableName(astNode)
-    if (SharkEnv.memoryMetadataManager.contains(oldTableName)) {
+    if (SharkEnv.memoryMetadataManager.contains(db.getCurrentDatabase(), oldTableName)) {
       val newTableName = BaseSemanticAnalyzer.getUnescapedName(
         astNode.getChild(1).asInstanceOf[ASTNode])
 

--- a/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
+++ b/src/main/scala/shark/parse/SharkSemanticAnalyzer.scala
@@ -189,8 +189,9 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
             OperatorFactory.createSharkFileOutputPlan(hiveSinkOp)
           } else {
             // Otherwise, check if we are inserting into a table that was cached.
-            val cachedTableName = tableName.split('.')(1) // Ignore the database name
-            SharkEnv.memoryMetadataManager.get(cachedTableName) match {
+        	val cachedTableName = tableName.split('.')(1) // Ignore the database name
+        	val databaseName = tableName.split('.')(0)
+            SharkEnv.memoryMetadataManager.get(databaseName, cachedTableName) match {
               case Some(rdd) => {
                 if (hiveSinkOps.size == 1) {
                   // If useUnionRDD is false, the sink op is for INSERT OVERWRITE.
@@ -199,6 +200,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
                   OperatorFactory.createSharkMemoryStoreOutputPlan(
                     hiveSinkOp,
                     cachedTableName,
+                    databaseName,
                     storageLevel,
                     _resSchema.size,                // numColumns
                     cacheMode == CacheType.TACHYON, // use tachyon
@@ -223,6 +225,7 @@ class SharkSemanticAnalyzer(conf: HiveConf) extends SemanticAnalyzer(conf) with 
             OperatorFactory.createSharkMemoryStoreOutputPlan(
               hiveSinkOps.head,
               qb.getTableDesc.getTableName,
+              qb.getTableDesc.getDatabaseName,
               storageLevel,
               _resSchema.size,                // numColumns
               cacheMode == CacheType.TACHYON, // use tachyon


### PR DESCRIPTION
Cached tables currently ignore database name which makes caching buggy for users using multiple databases.
Enhanced the memoryMetadataManager to require database name inaddition to the tablename for all metadata operations.
