### PR TITLE
Catch exceptions thrown by threads launched in ScriptOperator and get Shark to compile with latest Spark master.

### DIFF
--- a/src/main/scala/shark/execution/FileSinkOperator.scala
+++ b/src/main/scala/shark/execution/FileSinkOperator.scala
@@ -17,6 +17,9 @@
 
 package shark.execution
 
+import java.text.SimpleDateFormat
+import java.util.Date
+
 import scala.reflect.BeanProperty
 
 import org.apache.hadoop.fs.FileSystem
@@ -25,7 +28,7 @@ import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.exec.{FileSinkOperator => HiveFileSinkOperator}
 import org.apache.hadoop.hive.ql.exec.JobCloseFeedBack
 import org.apache.hadoop.hive.shims.ShimLoader
-import org.apache.hadoop.mapred.TaskID
+import org.apache.hadoop.mapred.{JobID, TaskID}
 import org.apache.hadoop.mapred.TaskAttemptID
 import org.apache.hadoop.mapred.SparkHadoopWriter
 
@@ -51,9 +54,15 @@ class FileSinkOperator extends TerminalOperator with Serializable {
   }
 
   def setConfParams(conf: HiveConf, context: TaskContext) {
+    def createJobID(time: Date, id: Int): JobID = {
+      val formatter = new SimpleDateFormat("yyyyMMddHHmm")
+      val jobtrackerID = formatter.format(new Date())
+      return new JobID(jobtrackerID, id)
+    }
+
     val jobID = context.stageId
     val splitID = context.splitId
-    val jID = SparkHadoopWriter.createJobID(now, jobID)
+    val jID = createJobID(now, jobID)
     val taID = new TaskAttemptID(new TaskID(jID, true, splitID), 0)
     conf.set("mapred.job.id", jID.toString)
     conf.set("mapred.tip.id", taID.getTaskID.toString)

--- a/src/main/scala/shark/execution/ScriptOperator.scala
+++ b/src/main/scala/shark/execution/ScriptOperator.scala
@@ -20,9 +20,11 @@ package shark.execution
 import java.io.{File, InputStream, IOException}
 import java.lang.Thread.UncaughtExceptionHandler
 import java.util.{Arrays, Properties}
+
 import scala.collection.JavaConversions._
 import scala.io.Source
 import scala.reflect.BeanProperty
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.exec.{ScriptOperator => HiveScriptOperator}
@@ -32,9 +34,11 @@ import org.apache.hadoop.hive.ql.plan.ScriptDesc
 import org.apache.hadoop.hive.serde2.{Serializer, Deserializer}
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 import org.apache.hadoop.io.{BytesWritable, Writable}
+
 import org.apache.spark.{OneToOneDependency, SparkEnv, SparkFiles}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.TaskContext
+
 import shark.execution.serialization.OperatorSerializationWrapper
 import shark.LogHelper
 
@@ -119,7 +123,6 @@ class ScriptOperator extends UnaryOperator[HiveScriptOperator] {
           SparkEnv.set(sparkEnv)
           val recordWriter = inRecordWriterClass.newInstance
           recordWriter.initialize(proc.getOutputStream, op.localHconf)
-
           for (elem <- iter) {
             recordWriter.write(elem)
           }
@@ -253,6 +256,7 @@ object ScriptOperator {
     with LogHelper {
 
     override def uncaughtException(thread: Thread, throwable: Throwable) {
+      Thread.sleep(7000)
       throwable match {
         case ioe: IOException => {
           // Check whether the IOException should be re-thrown by the parent thread.
@@ -265,6 +269,7 @@ object ScriptOperator {
                 .format(HiveConf.ConfVars.ALLOWPARTIALCONSUMP.toString))
               throw ioe
             }
+            println("thread finished...")
             context.synchronized {
               context.addOnCompleteCallback(onCompleteCallback)
             }

--- a/src/main/scala/shark/execution/ScriptOperator.scala
+++ b/src/main/scala/shark/execution/ScriptOperator.scala
@@ -17,26 +17,26 @@
 
 package shark.execution
 
-import java.io.{File, InputStream}
+import java.io.{File, InputStream, IOException}
+import java.lang.Thread.UncaughtExceptionHandler
 import java.util.{Arrays, Properties}
-
 import scala.collection.JavaConversions._
 import scala.io.Source
 import scala.reflect.BeanProperty
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.exec.{ScriptOperator => HiveScriptOperator}
 import org.apache.hadoop.hive.ql.exec.{RecordReader, RecordWriter, ScriptOperatorHelper}
+import org.apache.hadoop.hive.ql.metadata.HiveException
 import org.apache.hadoop.hive.ql.plan.ScriptDesc
 import org.apache.hadoop.hive.serde2.{Serializer, Deserializer}
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 import org.apache.hadoop.io.{BytesWritable, Writable}
-
 import org.apache.spark.{OneToOneDependency, SparkEnv, SparkFiles}
 import org.apache.spark.rdd.RDD
-
+import org.apache.spark.TaskContext
 import shark.execution.serialization.OperatorSerializationWrapper
+import shark.LogHelper
 
 
 /**
@@ -67,7 +67,7 @@ class ScriptOperator extends UnaryOperator[HiveScriptOperator] {
     logDebug("Using %s and %s".format(outRecordReaderClass, inRecordWriterClass))
 
     // Deserialize the output from script back to what Hive understands.
-    inputRdd.mapPartitions { part =>
+    inputRdd.mapPartitionsWithContext { (context, part) =>
       op.initializeOnSlave()
 
       // Serialize the data so it is recognizable by the script.
@@ -98,27 +98,34 @@ class ScriptOperator extends UnaryOperator[HiveScriptOperator] {
       val sparkEnv = SparkEnv.get
 
       // Start a thread to print the process's stderr to ours
-      new Thread("stderr reader for " + command) {
+      val errorReaderThread = new Thread("stderr reader for " + command) {
         override def run() {
-          for(line <- Source.fromInputStream(proc.getErrorStream).getLines) {
+          for (line <- Source.fromInputStream(proc.getErrorStream).getLines) {
             System.err.println(line)
           }
         }
-      }.start()
+      }
+      errorReaderThread.setUncaughtExceptionHandler(
+        new ScriptOperator.ScriptExceptionHandler(op, context))
+      errorReaderThread.start()
 
       // Start a thread to feed the process input from our parent's iterator
-      new Thread("stdin writer for " + command) {
+      val inputWriterThread = new Thread("stdin writer for " + command) {
         override def run() {
           // Set the thread local SparkEnv.
           SparkEnv.set(sparkEnv)
           val recordWriter = inRecordWriterClass.newInstance
           recordWriter.initialize(proc.getOutputStream, op.localHconf)
-          for(elem <- iter) {
+
+          for (elem <- iter) {
             recordWriter.write(elem)
           }
           recordWriter.close()
         }
-      }.start()
+      }
+      inputWriterThread.setUncaughtExceptionHandler(
+        new ScriptOperator.ScriptExceptionHandler(op, context))
+      inputWriterThread.start()
 
       // Return an iterator that reads outputs from RecordReader. Use our own
       // BinaryRecordReader if necessary because Hive's has a bug (see below).
@@ -218,6 +225,9 @@ class ScriptOperator extends UnaryOperator[HiveScriptOperator] {
     }
   }
 
+  def allowPartialConsumption: Boolean =
+    HiveConf.getBoolVar(localHconf, HiveConf.ConfVars.ALLOWPARTIALCONSUMP)
+
   def serializeForScript[T](iter: Iterator[T]): Iterator[Writable] =
     iter.map { row => scriptInputSerializer.serialize(row, objectInspector) }
 
@@ -226,6 +236,45 @@ class ScriptOperator extends UnaryOperator[HiveScriptOperator] {
 }
 
 object ScriptOperator {
+
+  /**
+   * A general exception handler to attach to child threads used to feed input rows and forward
+   * errors to the parent thread during ScriptOperator#execute().
+   * If partial query consumption is not allowed (see HiveConf.Confvars.ALLOWPARTIALCONSUMP), then
+   * exceptions from child threads are caught by the handler and re-thrown by the parent thread
+   * through an on-task-completion callback registered with the Spark TaskContext. The task will be
+   * marked "failed" and the exception will be propagated to the master/CLI.
+   */
+  class ScriptExceptionHandler(
+      serializedScriptOp: OperatorSerializationWrapper[ScriptOperator], context: TaskContext)
+    extends UncaughtExceptionHandler
+    with LogHelper {
+
+    override def uncaughtException(thread: Thread, throwable: Throwable) {
+      throwable match {
+        case ioe: IOException => {
+          // Check whether the IOException should be re-thrown by the parent thread.
+          if (serializedScriptOp.allowPartialConsumption) {
+            logWarning("Error while executing script. Ignoring %s"
+              .format(ioe.getMessage))
+          } else {
+            val onCompleteCallback = () => {
+              logWarning("Error during script execution. Set %s=true to ignore thrown IOExceptions."
+                .format(HiveConf.ConfVars.ALLOWPARTIALCONSUMP.toString))
+              throw ioe
+            }
+            context.addOnCompleteCallback(onCompleteCallback)
+          }
+        }
+        case _ => {
+          // Throw any other Exceptions or Errors.
+          val onCompleteCallback = () => throw throwable
+          context.addOnCompleteCallback(onCompleteCallback)
+        }
+      }
+    }
+
+  }
 
   /**
    * An iterator that wraps around a Hive RecordReader.


### PR DESCRIPTION
Two additions in this PR, but both are relatively small and needed to get Jenkins passing.
- Exceptions thrown by threads launched in ScriptOperator are now caught and rethrown by on-complete-callbacks registered with the TaskContext used to compute the corresponding RDD.
- SparkHadoopWriter#createJobID() access was changed here: https://github.com/apache/incubator-spark/pull/88, but the fix is pretty small - just copied createJobID() and made it a nested function in FileSinkOperator...
