### PR TITLE
CancelJob through JDBC Clients 

### DIFF
--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -43,7 +43,7 @@ import org.apache.hadoop.hive.ql.processors.{CommandProcessor, CommandProcessorF
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.shims.ShimLoader
 import org.apache.hadoop.io.IOUtils
-import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TSocket
 
 
 
@@ -69,7 +69,7 @@ object SharkCliDriver {
         } else {
           if (transport != null) {
             // Force closing of TCP connection upon session termination
-        	transport.getSocket().close()
+            transport.getSocket().close()
           }
         }
       }

--- a/src/main/scala/shark/SharkCliDriver.scala
+++ b/src/main/scala/shark/SharkCliDriver.scala
@@ -43,13 +43,16 @@ import org.apache.hadoop.hive.ql.processors.{CommandProcessor, CommandProcessorF
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.hive.shims.ShimLoader
 import org.apache.hadoop.io.IOUtils
+import org.apache.thrift.transport.TSocket;
+
 
 
 object SharkCliDriver {
 
   private var prompt  = "shark"
   private var prompt2 = "     " // when ';' is not yet seen.
-
+  private var transport:TSocket = _
+    
   installSignalHandler()
 
   /**
@@ -60,7 +63,15 @@ object SharkCliDriver {
   def installSignalHandler() {
     HiveInterruptUtils.add(new HiveInterruptCallback {
       override def interrupt() {
-        SharkEnv.sc.cancelAllJobs()
+        // Handle remote execution mode
+        if (SharkEnv.sc != null) {
+          SharkEnv.sc.cancelAllJobs()
+        } else {
+          if (transport != null) {
+            // Force closing of TCP connection upon session termination
+        	transport.getSocket().close()
+          }
+        }
       }
     })
   }
@@ -198,6 +209,11 @@ object SharkCliDriver {
       "spacesForString", classOf[String])
     spacesForStringMethod.setAccessible(true)
 
+    val clientTransportTSocketField = classOf[CliSessionState].getDeclaredField("transport")
+    clientTransportTSocketField.setAccessible(true)
+
+    transport = clientTransportTSocketField.get(ss).asInstanceOf[TSocket]
+    
     var ret = 0
 
     var prefix = ""

--- a/src/main/scala/shark/SharkEnv.scala
+++ b/src/main/scala/shark/SharkEnv.scala
@@ -94,6 +94,8 @@ object SharkEnv extends LogHelper {
   executorEnvVars.put("TACHYON_MASTER", getEnv("TACHYON_MASTER"))
   executorEnvVars.put("TACHYON_WAREHOUSE_PATH", getEnv("TACHYON_WAREHOUSE_PATH"))
 
+  val activeSessions = new HashSet[String]
+  
   var sc: SparkContext = _
 
   val shuffleSerializerName = classOf[ShuffleSerializer].getName

--- a/src/main/scala/shark/SharkServer.scala
+++ b/src/main/scala/shark/SharkServer.scala
@@ -168,20 +168,20 @@ object SharkServer extends LogHelper {
   
   class JDBCWatcher(sock:java.net.Socket, sessionID:String) extends Thread {
     
-	override def run() {
-	  try {
-	    while (sock.isConnected && SharkEnv.activeSessions.contains(sessionID)) {	    
-	      sock.getOutputStream().write((new Array[Byte](0)).toArray)
-	      logDebug("Session Socket Alive - " + sessionID)
+    override def run() {
+      try {
+        while (sock.isConnected && SharkEnv.activeSessions.contains(sessionID)) {	    
+          sock.getOutputStream().write((new Array[Byte](0)).toArray)
+          logDebug("Session Socket Alive - " + sessionID)
           Thread.sleep(2*1000)
         }
-	  } catch {
-	      case ioe: IOException => Unit
-	  }
+      } catch {
+        case ioe: IOException => Unit
+      }
 
 
-	  logInfo("Session Socket connection lost, cleaning up - " + sessionID)
-	  SharkEnv.sc.cancelJobGroup(sessionID)
+      logInfo("Session Socket connection lost, cleaning up - " + sessionID)
+      SharkEnv.sc.cancelJobGroup(sessionID)
     }
 
   }

--- a/src/main/scala/shark/SharkServer.scala
+++ b/src/main/scala/shark/SharkServer.scala
@@ -98,8 +98,9 @@ object SharkServer extends LogHelper {
         
         val jdbcSocket = t.asInstanceOf[TSocket].getSocket()
         jdbcSocket.setKeepAlive(true)
-        val sessionID = remoteClient + "/" + System.currentTimeMillis()
-
+        val sessionID = remoteClient + "/" + jdbcSocket
+          .getRemoteSocketAddress().asInstanceOf[InetSocketAddress].getPort().toString
+        
         // Add and enable watcher thread
         val watcher = new JDBCWatcher(jdbcSocket, sessionID)
         SharkEnv.activeSessions.add(sessionID)


### PR DESCRIPTION
Handle disconnects relies on TCP keepalives (To be set using OS settings on server)
Allows explicit kill session/job groups through JDBC.
(Local mode job cleanup already handled)
