### PR TITLE
AST transformations for DISTINCT aggregates

### DIFF
--- a/src/main/scala/shark/parse/ASTNodeFactory.scala
+++ b/src/main/scala/shark/parse/ASTNodeFactory.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.parse
+
+import java.util.{List => JavaList}
+
+import scala.collection.JavaConversions._
+
+import org.antlr.runtime.CommonToken
+import org.apache.hadoop.hive.ql.parse.{ASTNode, HiveParser}
+
+
+object ASTNodeFactory {
+
+  def setText(node: ASTNode, newText: String): ASTNode = {
+    node.token.asInstanceOf[org.antlr.runtime.CommonToken].setText(newText)
+    node
+  }
+
+  def setChildren(node: ASTNode, newChildren: Seq[ASTNode]): ASTNode = {
+    (1 to node.getChildCount).foreach(_ => node.deleteChild(0))
+    node.addChildren(newChildren)
+    node
+  }
+
+  def queryNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_QUERY))
+    setText(newNode, "TOK_QUERY")
+    setChildren(newNode, children)
+  }
+
+  def fromNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_FROM))
+    setText(newNode, "TOK_FROM")
+    setChildren(newNode, children)
+  }
+
+  def subqueryNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_SUBQUERY))
+    setText(newNode, "TOK_SUBQUERY")
+    setChildren(newNode, children)
+  }
+
+  def insertNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_INSERT))
+    setText(newNode, "TOK_INSERT")
+    setChildren(newNode, children)    
+  }
+
+  def selectNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_SELECT))
+    setText(newNode, "TOK_SELECT")
+    setChildren(newNode, children)    
+  }
+
+  def selectDINode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_SELECTDI))
+    setText(newNode, "TOK_SELECTDI")
+    setChildren(newNode, children)    
+  }
+
+  def selectExprNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_SELEXPR))
+    setText(newNode, "TOK_SELEXPR")
+    setChildren(newNode, children)    
+  }
+
+  def functionStarNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_FUNCTIONSTAR))
+    setText(newNode, "TOK_FUNCTIONSTAR")
+    setChildren(newNode, children)    
+  }
+
+  def tmpFileNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_TMP_FILE))
+    setText(newNode, "TOK_TMP_FILE")
+    setChildren(newNode, children)    
+  }
+
+  def dirNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_DIR))
+    setText(newNode, "TOK_DIR")
+    setChildren(newNode, children)    
+  }
+
+  def destinationNode(children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.TOK_DESTINATION))
+    setText(newNode, "TOK_DESTINATION")
+    setChildren(newNode, children)    
+  }
+
+  def textNode(newText: String, children: Seq[ASTNode] = Nil): ASTNode = {
+    val newNode = new ASTNode(new org.antlr.runtime.CommonToken(HiveParser.Identifier))
+    setText(newNode, newText)
+    setChildren(newNode, children)
+  }
+}

--- a/src/main/scala/shark/parse/ASTRewriteUtil.scala
+++ b/src/main/scala/shark/parse/ASTRewriteUtil.scala
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark.parse
+
+import java.util.{List => JavaList}
+
+import scala.collection.mutable.{ArrayBuffer, Queue}
+import scala.collection.JavaConversions._
+
+import org.apache.hadoop.hive.ql.lib.Node
+import org.apache.hadoop.hive.ql.parse.{ASTNode, HiveParser}
+
+import shark.LogHelper
+import shark.parse.ASTNodeFactory._
+
+
+object ASTRewriteUtil extends LogHelper {
+
+  val DISTINCT_SUBQUERY_ALIAS = "subqueryAliasForCountDistinctRewrite_"
+
+  def getDistinctSubqueryAlias(id: Int) = {
+    DISTINCT_SUBQUERY_ALIAS + id
+  }
+
+  /** Prints the tree starting at the given `node` root */
+  def printTree(node: Node, builder: StringBuilder = new StringBuilder, indent: Int = 0)
+  : StringBuilder = {
+    node match {
+      case a: ASTNode => builder.append(("  " * indent) + a.getText + "\n")
+      case other => sys.error("Non ASTNode encountered: " + other)
+    }
+
+    Option(node.getChildren).map(_.toList).getOrElse(Nil).foreach(printTree(_, builder, indent + 1))
+    builder
+  }
+
+  /**
+   * Returns the children of `node`. Nil is returned if there are no children, as opposed the
+   * the NULL list that `node.getChildren` returns.
+   */
+  def getChildren(node: ASTNode): Seq[ASTNode] = {
+    Option(node.getChildren).map(_.toSeq).getOrElse(Nil).asInstanceOf[Seq[ASTNode]]
+  }
+
+  /**
+   * Returns a indicies to expressions in `selExprNodes` that contain nodes corresponding to
+   * `nodeTokenType`.
+   */
+  private def findIndicesForNodeTokenType(
+      selExprNodes: JavaList[ASTNode],
+      nodeTokenType: Int): Seq[Int] = {
+    val indices = new ArrayBuffer[Int]()
+    for ((selExprNode, index) <- selExprNodes.zipWithIndex) {
+      if (getNodeForTokenType(selExprNode, nodeTokenType).isDefined) {
+        indices += index
+      }
+    }
+    indices
+  }
+
+  /**
+   * Returns the node corresponding to `tokenType` reachable from `node`.
+   * Only the first child from a node is traversed, so this should only be used to find
+   * TOK_FUNCTIONDI or TOK_FUNCTION nodes.
+   *
+   * Note:
+   * TOK_FUNCTIONDI can be nested if there are multiple expressions selected. For example,
+   *   SELECT COUNT(DISTINCT key) * 10 + 5 ...
+   * will have two nodes, one each for "+" and "*", between TOK_SELEXPR and TOK_FUNCTIONDI nodes.
+   */
+  private def getNodeForTokenType(node: ASTNode, tokenType: Int): Option[ASTNode] = {
+    if (node.getToken.getType == tokenType) {
+      Some(node)
+    } else {
+      val children = getChildren(node)
+      if (children.isEmpty) {
+        None
+      } else {
+        getNodeForTokenType(children.head.asInstanceOf[ASTNode], tokenType)
+      }
+    }
+  }
+
+  private def hasGroupByInChildren(nodes: JavaList[ASTNode]): Boolean = {
+    for (node <- nodes) {
+      if (node.getToken.getType == HiveParser.TOK_GROUPBY) {
+        return true
+      }
+    }
+    false
+  }
+
+  /** Returns all TOK_QUERY nodes found using breadth-first traversal, including `rootAstNode`. */
+  private def findQueryNodes(rootAstNode: ASTNode): Seq[ASTNode] = {
+    def isQueryNode(node: ASTNode): Boolean = node.getToken.getType == HiveParser.TOK_QUERY
+
+    val foundQueryNodes = new ArrayBuffer[ASTNode]()
+    val queue = new Queue[ASTNode]()
+    queue.enqueue(rootAstNode)
+    while (!queue.isEmpty) {
+      val currentNode = queue.dequeue
+      if (isQueryNode(currentNode)) {
+        foundQueryNodes += currentNode
+      }
+      for (child <- getChildren(currentNode)) {
+        queue.enqueue(child)
+      }
+    }
+    foundQueryNodes.toSeq
+  }
+
+  /**
+   * Main entry point for DISTINCT aggregate rewrites. After the function returns, for each
+   * (sub)query, a DISTINCT aggregate expression without a partitoning key will be reordered
+   * into an aggregation over a DISTINCT subquery.
+   * This function finds all TOK_QUERY nodes and delegates to countDistinctQueryToGroupBy() for
+   * rewriting any query with a DISTINCT aggregate.
+   */
+  def countDistinctToGroupBy(rootAstNode: ASTNode): ASTNode = {
+    // Find all TOK_QUERY nodes and transform any count-distincts subtree into a one with a
+    // distinct/hash partition.
+    val queryNodes = findQueryNodes(rootAstNode)
+    for ((queryNode, queryId) <- queryNodes.zipWithIndex) {
+      countDistinctQueryToGroupBy(queryNode, queryId)
+    }
+    rootAstNode
+  }
+
+  /**
+   * Starting at the TOK_QUERY node, detects whether there is a DISTINCT aggregate without a
+   * partitioning key. If so, calls reorderCountDistinctToGroupBy() to do an AST transformation into
+   * an aggregation over a DISTINCT subquery.
+   *
+   * @param rootAstNode Root node for the AST to transform.
+   * @param queryId Unique ID for the query starting at `rootAstNode`. For a command with multiple
+   *                subqueries, countDistinctQueryToGroupBy() will be called multiple times, each
+   *                with a different `queryId` argument.
+   */
+  private def countDistinctQueryToGroupBy(rootAstNode: ASTNode, queryId: Int): ASTNode = {
+    if (rootAstNode.getToken.getType == HiveParser.TOK_QUERY) {
+      val rootQueryChildren = getChildren(rootAstNode)
+      if (rootQueryChildren.size == 2) {
+        // TOK_QUERY always has two children, TOK_FROM and TOK_INSERT, in order.
+        val (fromClause, insertStmt) = (rootQueryChildren.get(0), rootQueryChildren.get(1))
+        val insertStmtChildren = getChildren(insertStmt)
+        if (insertStmtChildren.size >= 2 && !hasGroupByInChildren(insertStmtChildren)) {
+          // The subtree starting at TOK_INSERT has this structure (parenthesis indicate children):
+          // TOK_INSERT (TOK_DESTINATION ... ) (TOK_SELECT (TOK_SELEXPR (TOK_FUNCTIONDI ... )))
+          // Note that at this point, the insert statement can have more than 2 children if there
+          // is a WHERE filter and/or an ORDER BY or SORT BY.
+          val (destinationAndSelectStmt, stmtClauses) = insertStmtChildren.splitAt(2)
+          val destination = destinationAndSelectStmt.get(0)
+          val selectStmt = destinationAndSelectStmt.get(1)
+          val selectExprs = getChildren(selectStmt)
+          // With respect to the select node's children list, find the index to the TOK_SELEXPR root
+          // for the subtree that contains the TOK_FUNCTIONDI parent of the distinct aggregate
+          // function node.
+          val distinctFunctionIndices = findIndicesForNodeTokenType(selectExprs,
+            HiveParser.TOK_FUNCTIONDI)
+          val functionIndices = findIndicesForNodeTokenType(selectExprs,
+            HiveParser.TOK_FUNCTION)
+          if (distinctFunctionIndices.size == 1 && functionIndices.isEmpty) {
+            setChildren(insertStmt, destinationAndSelectStmt)
+            // We've found a distinct aggregate - rewrite.
+            val distinctFunctionIndex = distinctFunctionIndices.get(0)
+            val selectExpr = selectExprs.get(distinctFunctionIndex)
+            // TODO(harvey): Might be nice (though verbose) to print the before/after trees.
+            logInfo("Rewriting a detected DISTINCT aggregate.")
+            reorderCountDistinctToGroupBy(
+              rootAstNode,
+              fromClause,
+              destination,
+              selectExpr,
+              stmtClauses,
+              queryId)
+          }
+        }
+      }
+    }
+    rootAstNode
+  }
+
+  /**
+   * Rewrites a query with a distinct aggregate to one with an aggregation over a distinct subquey.
+   * For example, this AST:
+   *   TOK_QUERY
+   *     TOK_FROM
+   *       TOK_TABREF
+   *         TOK_TABNAME
+   *           src
+   *     TOK_INSERT
+   *       TOK_DESTINATION
+   *         TOK_DIR
+   *           TOK_TMP_FILE
+   *       TOK_SELECT
+   *         TOK_SELEXPR
+   *           TOK_FUNCTIONDI
+   *             count
+   *             TOK_TABLE_OR_COL
+   *               key
+   * corresponding to the query:
+   *   SELECT COUNT(DISTINCT key) FROM src
+   *
+   * is transformed into:
+   *   TOK_QUERY
+   *     TOK_FROM
+   *       TOK_SUBQUERY
+   *         TOK_QUERY
+   *           TOK_FROM
+   *             TOK_TABREF
+   *               TOK_TABNAME
+   *                 src
+   *           TOK_INSERT
+   *             TOK_DESTINATION
+   *               TOK_DIR
+   *                 TOK_TMP_FILE
+   *             TOK_SELECTDI
+   *               TOK_SELEXPR
+   *                 TOK_TABLE_OR_COL
+   *                   key
+   *         subqueryAliasForCountDistinctRewrite_0
+   *     TOK_INSERT
+   *       TOK_DESTINATION
+   *         TOK_DIR
+   *           TOK_TMP_FILE
+   *       TOK_SELECT
+   *         TOK_SELEXPR
+   *           TOK_FUNCTIONSTAR
+   *             count
+   * corresponding to the query:
+   *   SELECT COUNT(*) FROM
+   *     (SELECT DISTINCT key FROM src) subqueryAliasForCountDistinctRewrite_0
+   */
+  private def reorderCountDistinctToGroupBy(
+      rootQuery: ASTNode,
+      fromClause: ASTNode,
+      destination: ASTNode,
+      selectExpr: ASTNode,
+      stmtClauses: Seq[ASTNode],
+      queryId: Int): ASTNode = {
+    // Construct the subtree starting at the TOK_INSERT child of `rootQuery`.
+
+    // Separate the text node containing the distinct function name from the function arguments.
+    val distinctFunction = getNodeForTokenType(selectExpr, HiveParser.TOK_FUNCTIONDI).get
+    val distinctFunctionChildren = distinctFunction.asInstanceOf[ASTNode].getChildren
+    val distinctFunctionName = distinctFunctionChildren.get(0).asInstanceOf[ASTNode]
+    val distinctFunctionArgs = distinctFunctionChildren.subList(
+      1, distinctFunctionChildren.size)
+
+    // Transform the TOK_FUNCTIONDI node from the original AST into a TOK_FUNCTIONSTAR and attach
+    // the text node containing the distinct function name as the only child.
+    // This subtree starting at TOK_FUNCTIONDI is the only component that is modified.
+    distinctFunction.token = new org.antlr.runtime.CommonToken(HiveParser.TOK_FUNCTIONSTAR)
+    setText(distinctFunction, "TOK_FUNCTIONSTAR")
+    val functionStar = distinctFunction
+    setChildren(functionStar, Seq(distinctFunctionName))
+
+    // Construct the subtree starting at the TOK_FROM root child of `rootQuery`, from the bottom-up.
+
+    // Create a subtree, starting at a TOK_DESTINATION node, that represents a temporary directory.
+    val tmpDestination = destinationNode(Seq(dirNode(Seq(tmpFileNode(Nil)))))
+    // Create a subtree, starting at a TOK_SELECTDI node.
+    // Assign a TOK_SELEXPR parent for each expression argument to the distinct aggregate function.
+    // These will be the children of the TOK_SELECTDI node.
+    val selectDistinctExprs =
+      for (arg <- distinctFunctionArgs.asInstanceOf[JavaList[ASTNode]]) yield {
+        selectExprNode(Seq(arg))
+      }
+    val selectDistinctStmt = selectDINode(selectDistinctExprs)
+
+    // Add the TOK_DESTINATION and TOK_SELECTDI subtrees as the children of the TOK_INSERT node.
+    val insertStmt = insertNode(Seq(tmpDestination, selectDistinctStmt) ++ stmtClauses)
+    // Piece together the subtree starting at a TOK_SUBQUERY node.
+    val subqueryAlias = textNode(getDistinctSubqueryAlias(queryId))
+    val subquery = subqueryNode(Seq(queryNode(Seq(fromClause, insertStmt)), subqueryAlias))
+    // Create and set TOK_FROM as the first child of the root TOK_QUERY.
+    val outerFromClause = fromNode(Seq(subquery))
+    rootQuery.setChild(0, outerFromClause)
+
+    rootQuery
+  }
+}

--- a/src/test/scala/shark/CountDistinctRewriteSuite.scala
+++ b/src/test/scala/shark/CountDistinctRewriteSuite.scala
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2012 The Regents of The University California.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shark
+
+import java.util.{List => JavaList}
+
+import scala.collection.JavaConversions._
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuite
+
+import org.apache.hadoop.hive.ql.lib.Node
+import org.apache.hadoop.hive.ql.parse.{ASTNode, HiveParser}
+import org.apache.hadoop.hive.ql.parse.{ParseDriver, ParseUtils}
+
+import shark.api.QueryExecutionException
+import shark.parse.ASTRewriteUtil
+import shark.parse.ASTRewriteUtil._
+
+
+class CountDistinctRewriteSuite extends FunSuite with BeforeAndAfterAll {
+
+  /**
+   * Throws an error if this is not equal to other.
+   *
+   * Right now this function only checks the name, type, text and children of the node
+   * for equality.
+   */
+  def checkEquals(node: ASTNode, other: ASTNode) {
+    def check(field: String, func: ASTNode => Any) {
+      assert(func(node) == func(other),
+        "node: \n" + printTree(node) + "\nis not equal to: \n" + printTree(other) +
+        "\n for field: " + field)
+    }
+
+    check("name", _.getName)
+    check("type", _.getType)
+    check("text", _.getText)
+    check("numChildren", (node: ASTNode) => getChildren(node).size)
+
+    val leftChildren = getChildren(node)
+    val rightChildren = getChildren(other)
+    leftChildren.zip(rightChildren).foreach {
+      case (l,r) => checkEquals(l, r)
+    }
+  }
+
+  def genAST(command: String): ASTNode = {
+    try {
+      ParseUtils.findRootNonNullToken((new ParseDriver()).parse(command))
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException("Failed to parse: " + command)
+    }
+  }
+
+  test("Count distinct, single column") {
+    val command = genAST("select count(distinct key) from src")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("select count(*) from (select distinct key from src) %s"
+      .format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("Count distinct, multiple columns") {
+    val command = genAST("select count(distinct key, value) from src")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("select count(*) from (select distinct key, value from src) %s"
+      .format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("Multiple columns with expressions") {
+    val command = genAST("select count(distinct key * 10 - 3, substr(value, 5)) from src")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST(
+      "select count(*) from (select distinct key * 10 - 3, substr(value, 5) from src) %s"
+      .format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("Distinct function outputs") {
+    val command = genAST("select count(distinct substr(val, 5)) from src")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("""
+      select count(*) from (select distinct substr(val, 5) from src) %s"""
+        .format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("Constants aside COUNT DISTINCT in SELECT list") {
+    val command1 = genAST("select 1, 2, count(distinct key) from src")
+    val rewrite1 = ASTRewriteUtil.countDistinctToGroupBy(command1)
+    val expectedRewrite1 = genAST("""
+      select 1, 2, count(*) from (select distinct key from src) %s"""
+        .format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite1, expectedRewrite1)
+
+    val command2 = genAST("select 1, count(distinct key), 2, 3 from src")
+    val rewrite2 = ASTRewriteUtil.countDistinctToGroupBy(command2)
+    val expectedRewrite2 = genAST("""
+      select 1, count(*), 2, 3 from (select distinct key from src) %s"""
+        .format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite2, expectedRewrite2)
+  }
+
+  test("COUNT DISTINCT as part of an expression") {
+    val command = genAST("select count(distinct key) + 10 from src")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("""
+      select count(*) + 10 from (select distinct key from src) %s"""
+        .format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("COUNT DISTINCT as part of a subquery") {
+    val command = genAST("select * from (select count(distinct key) + 10 from src) numDistincts")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("""
+      select * from
+        (select count(*) + 10 from
+          (select distinct key from src) %s) numDistincts
+      """.format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "1"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("COUNT DISTINCT from results of a subquery") {
+    val command = genAST("""
+      select count(distinct a.val) from
+        (select * from src where key is null) a
+        join
+        (select * from src where key is null) b on a.key = b.key
+      """)
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("""
+      select count(*) from
+        (select distinct a.val from
+          (select * from src where key is null) a
+          join
+          (select * from src where key is null) b on a.key = b.key
+        ) %s
+      """.format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "0"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("COUNT DISTINCT from the results of a subquery, as part of an outer subquery") {
+    val command = genAST("""
+      select * from (
+        select count(distinct a.val) from
+          (select * from src where key is null) a
+          join
+          (select * from src where key is null) b on a.key = b.key
+        ) numDistincts
+      """)
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("""
+      select * from
+        (select count(*) from
+          (select distinct a.val from
+            (select * from src where key is null) a
+            join
+            (select * from src where key is null) b on a.key = b.key
+          ) %s
+        ) numDistincts 
+      """.format(ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "1"))
+    checkEquals(rewrite, expectedRewrite)
+  }
+
+  test("Union multiple count distincts") {
+    val command = genAST("""
+      select * from (
+        select count(distinct key) from src
+        union all
+        select count(distinct value) from src
+        union all
+        select count(distinct key) from src1
+        union all
+        select count(distinct value) from src2
+      ) distinctKVs""")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("""
+      select * from (
+        select count(*) from (select distinct key from src) %s
+        union all
+        select count(*) from (select distinct value from src) %s
+        union all
+        select count(*) from (select distinct key from src1) %s
+        union all
+        select count(*) from (select distinct value from src2) %s
+      ) distinctKVs""".format(
+        ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "3",
+        ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "4",
+        ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "2",
+        ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "1"))
+    checkEquals(rewrite, expectedRewrite)    
+  }
+
+  test("Union multiple count distincts, both over subqueries") {
+    val command = genAST("""
+      select * from (
+        select count(distinct a.key) from
+          (select * from src where key is null) a
+          join
+          (select * from src where key is null) b on a.key = b.key
+        union all
+        select count(distinct c.value) from
+          (select * from src where value is null) c
+          join
+          (select * from src where value is null) d on c.value = d.value
+        ) distinctKVs""")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    val expectedRewrite = genAST("""
+      select * from (
+        select count(*) from
+          (select distinct a.key from
+            (select * from src where key is null) a
+            join
+            (select * from src where key is null) b on a.key = b.key
+          ) %s
+        union all
+        select count(*) from
+          (select distinct c.value from
+            (select * from src where value is null) c
+            join
+            (select * from src where value is null) d on c.value = d.value
+          ) %s 
+        ) distinctKVs""".format(
+          ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "1",
+          ASTRewriteUtil.DISTINCT_SUBQUERY_ALIAS + "2"))
+    checkEquals(rewrite, expectedRewrite)    
+  }
+
+  test("Multiple COUNT DISTINCT in SELECT expression list isn't rewritten (or supported yet)") {
+    val command = genAST("""
+      select
+        sum(key),
+        count(distinct key),
+        count(distinct value)
+      from src""")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    checkEquals(command, rewrite)
+  }
+
+  test("COUNT DISTINCT with partitioning key isn't rewritten") {
+    val command = genAST("select key, count(distinct value) from src group by key")
+    val rewrite = ASTRewriteUtil.countDistinctToGroupBy(command)
+    checkEquals(command, rewrite)
+  }
+}


### PR DESCRIPTION
#### Recap

For queries with DISTINCT aggregates that don’t have a GROUP BY (i.e., the query returns a single number), Shark relies on a single shuffle and reduce for both processing the distincts (using an in-memory sort) and the final aggregation. THis is a pretty severe bottleneck

Queries with GROUP BY aren’t an issue because full aggregation for each key can be done locally on a reducer after a hash-partitioned shuffle.

Note: This type of optimization will be moved to the optimizer level in a future dev cycle. For a preview, check out the Catalyst abstract ([link](http://spark-summit.org/talk/armbrust-catalyst-a-query-optimization-framework-for-spark-and-shark/)) and the corresponding slides ([download link](http://spark-summit.org/wp-content/uploads/2013/10/J-Michael-Armburst-catalyst-spark-summit-dec-2013.pptx))
#### Approach

Execution for DISTINCT aggregates (without GROUP BY) should be split into two shuffles: the first to hash-partition selected expressions and the second to rendezvous at a single reducer that will do the final aggregation.

<i> In the diagrams below, the nodes in red are modified and the nodes in blue are moved from the original AST. Nodes in green are directly instantiated in Shark. Nodes not colored remain unchanged. </i>

In the driver, `ASTRewriteUtil#countDistinctToGroupBy()` searches for patterns of the AST representation for

```
SELECT <aggregate fn>(DISTINCT <exprs>) FROM <source> <WHERE, ORDER BY, etc>
```

where `<source>` is a table, subquery, or a table or subquery alias.
![countdistinct 1](https://f.cloud.github.com/assets/1581364/1652614/9d949ede-5b1a-11e3-9770-fe7b7e607f7c.png)

Then, for each subtree that matches the pattern, transform it to the AST representation for the rewriten query, 

```
SELECT <aggregate fn>(*) FROM
   (SELECT DISTINCT <exprs> FROM <source> <WHERE, ORDER BY, etc>) <Shark-internal alias>
```

![countdistinctrewrite 1](https://f.cloud.github.com/assets/1581364/1652616/a2fabd2c-5b1a-11e3-9ccf-7914c54d3c3a.png)
