### PR TITLE
Upgrade to scala 2.10

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -30,7 +30,7 @@ object SharkBuild extends Build {
 
   val SPARK_VERSION = "0.9.0-incubating-SNAPSHOT"
 
-  val SCALA_VERSION = "2.9.3"
+  val SCALA_VERSION = "2.10.3"
 
   // Hadoop version to build against. For example, "0.20.2", "0.20.205.0", or
   // "1.0.1" for Apache releases, or "0.20.2-cdh3u3" for Cloudera Hadoop.
@@ -65,7 +65,7 @@ object SharkBuild extends Build {
     organization := "edu.berkeley.cs.amplab",
     version := SHARK_VERSION,
     scalaVersion := SCALA_VERSION,
-    scalacOptions := Seq("-deprecation", "-unchecked", "-optimize"),
+    scalacOptions := Seq("-deprecation", "-unchecked", "-optimize", "-feature", "-Yinline-warnings"),
     parallelExecution in Test := false,
 
     // Download managed jars into lib_managed.
@@ -79,6 +79,7 @@ object SharkBuild extends Build {
     fork := true,
     javaOptions += "-XX:MaxPermSize=512m",
     javaOptions += "-Xmx2g",
+    javaOptions += "-Dsun.io.serialization.extendedDebugInfo=true",
 
     testOptions in Test += Tests.Argument("-oF"), // Full stack trace on test failures
 

--- a/run
+++ b/run
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # This file is used to launch Shark on the master.
-export SCALA_VERSION=2.9.3
-SHARK_VERSION=0.8.0-SNAPSHOT
+export SCALA_VERSION=2.10
+SHARK_VERSION=0.9.0-SNAPSHOT
 
 # Figure out where the framework is installed
 FWDIR="$(cd `dirname $0`; pwd)"

--- a/src/main/resources/tablerdd/RDDTable_generator.py
+++ b/src/main/resources/tablerdd/RDDTable_generator.py
@@ -46,10 +46,13 @@ package shark.api
 
 // *** This file is auto-generated from RDDTable_generator.py ***
 
+import scala.language.implicitConversions
+
 import org.apache.spark.rdd.RDD
+import scala.reflect.ClassTag
 
 object RDDTableImplicits {
-  private type M[T] = ClassManifest[T]
+  private type C[T] = ClassTag[T]
 
 """
 
@@ -62,7 +65,7 @@ for x in range(2,23):
   implicit def rddToTable$num[$tmlist]
   (rdd: RDD[($tlist)]): RDDTableFunctions = RDDTable(rdd)
 
-""").substitute(num = x, tmlist = createList(1, x, "T", ": M", ", ", indent=4), tlist = createList(1, x, "T", "", ", ", indent=4))
+""").substitute(num = x, tmlist = createList(1, x, "T", ": C", ", ", indent=4), tlist = createList(1, x, "T", "", ", ", indent=4))
     p.write(tableClass)
 
 prefix = """
@@ -70,8 +73,8 @@ prefix = """
 
 object RDDTable {
 
-  private type M[T] = ClassManifest[T]
-  private def m[T](implicit m : ClassManifest[T]) = classManifest[T](m)
+  private type C[T] = ClassTag[T]
+  private def ct[T](implicit c : ClassTag[T]) = c
 """
 
 p.write(prefix)
@@ -82,13 +85,13 @@ for x in range(2,23):
 """
   def apply[$tmlist]
   (rdd: RDD[($tlist)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
     new RDDTableFunctions(rddSeq, Seq($mtlist))
   }
 
-""").substitute(tmlist = createList(1, x, "T", ": M", ", ", indent=4), tlist = createList(1, x, "T", "", ", ", indent=4),
-                mtlist = createList(1, x, "m[T", "]", ", ", indent=4))
+""").substitute(tmlist = createList(1, x, "T", ": C", ", ", indent=4), tlist = createList(1, x, "T", "", ", ", indent=4),
+                mtlist = createList(1, x, "ct[T", "]", ", ", indent=4))
     p.write(tableClass)
 
 

--- a/src/main/resources/tablerdd/TableRDDGenerated_generator.py
+++ b/src/main/resources/tablerdd/TableRDDGenerated_generator.py
@@ -35,6 +35,8 @@ package shark.api
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{TaskContext, Partition}
 
+import scala.reflect.ClassTag
+
 class TableSeqRDD(prev: TableRDD)
   extends RDD[Seq[Any]](prev) {
 
@@ -63,16 +65,16 @@ for x in range(1,23):
     tableClass = Template(
 """
 class TableRDD$num[$list](prev: TableRDD,
-                       mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple$num[$list]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == $num, "Table only has " + tableCols + " columns, expecting $num")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 

--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -17,6 +17,8 @@
 
 package shark
 
+import scala.language.existentials
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hive.conf.HiveConf
 

--- a/src/main/scala/shark/SharkContext.scala
+++ b/src/main/scala/shark/SharkContext.scala
@@ -22,6 +22,7 @@ import java.util.{ArrayList => JArrayList}
 
 import scala.collection.Map
 import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
 
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.ql.Driver
@@ -49,8 +50,8 @@ class SharkContext(
   SharkContext.init()
   import SharkContext._
 
-  private type M[T] = ClassManifest[T]
-  private def m[T](implicit m : ClassManifest[T]) = classManifest[T](m)
+  private type C[T] = ClassTag[T]
+  private def ct[T](implicit c : ClassTag[T]) = c
 
 
   /**
@@ -122,158 +123,158 @@ class SharkContext(
    * a SELECT statement.
    */
 
-  def sqlRdd[T1: M, T2: M](cmd: String):
+  def sqlRdd[T1: C, T2: C](cmd: String):
   RDD[Tuple2[T1, T2]] = {
     new TableRDD2[T1, T2](sql2rdd(cmd),
-      Seq(m[T1], m[T2]))
+      Seq(ct[T1], ct[T2]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C](cmd: String):
   RDD[Tuple3[T1, T2, T3]] = {
     new TableRDD3[T1, T2, T3](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3]))
+      Seq(ct[T1], ct[T2], ct[T3]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C](cmd: String):
   RDD[Tuple4[T1, T2, T3, T4]] = {
     new TableRDD4[T1, T2, T3, T4](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C](cmd: String):
   RDD[Tuple5[T1, T2, T3, T4, T5]] = {
     new TableRDD5[T1, T2, T3, T4, T5](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C](cmd: String):
   RDD[Tuple6[T1, T2, T3, T4, T5, T6]] = {
     new TableRDD6[T1, T2, T3, T4, T5, T6](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C](cmd: String):
   RDD[Tuple7[T1, T2, T3, T4, T5, T6, T7]] = {
     new TableRDD7[T1, T2, T3, T4, T5, T6, T7](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C](cmd: String):
   RDD[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] = {
     new TableRDD8[T1, T2, T3, T4, T5, T6, T7, T8](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C](cmd: String):
   RDD[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = {
     new TableRDD9[T1, T2, T3, T4, T5, T6, T7, T8, T9](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C](cmd: String):
   RDD[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = {
     new TableRDD10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C](cmd: String):
   RDD[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = {
     new TableRDD11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C](cmd: String):
   RDD[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] = {
     new TableRDD12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C](cmd: String):
   RDD[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] = {
     new TableRDD13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C](cmd: String):
   RDD[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] = {
     new TableRDD14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C](cmd: String):
   RDD[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] = {
     new TableRDD15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M, T16: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C, T16: C](cmd: String):
   RDD[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] = {
     new TableRDD16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15], m[T16]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15], ct[T16]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M, T16: M, T17: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C, T16: C, T17: C](cmd: String):
   RDD[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] = {
     new TableRDD17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15], m[T16], m[T17]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15], ct[T16], ct[T17]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M, T16: M, T17: M, T18: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C, T16: C, T17: C, T18: C](cmd: String):
   RDD[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] = {
     new TableRDD18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15], m[T16], m[T17], m[T18]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], ct[T18]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C](cmd: String):
   RDD[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
     T19]] = {
     new TableRDD19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
       T19](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], ct[T18], ct[T19]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M, T20: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, T20: C](cmd: String):
   RDD[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
     T19, T20]] = {
     new TableRDD20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
       T19, T20](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19], m[T20]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], ct[T18], ct[T19], ct[T20]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M, T20: M, T21: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, T20: C, T21: C](cmd: String):
   RDD[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
     T19, T20, T21]] = {
     new TableRDD21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
       T19, T20, T21](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19], m[T20], m[T21]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], ct[T18], ct[T19], ct[T20], ct[T21]))
   }
 
-  def sqlRdd[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M, T11: M, T12: M,
-  T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M, T20: M, T21: M, T22: M](cmd: String):
+  def sqlRdd[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, T11: C, T12: C,
+  T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, T20: C, T21: C, T22: C](cmd: String):
   RDD[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
     T19, T20, T21, T22]] = {
     new TableRDD22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
       T19, T20, T21, T22](sql2rdd(cmd),
-      Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10], m[T11], m[T12],
-        m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19], m[T20], m[T21], m[T22]))
+      Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], ct[T10], ct[T11], ct[T12],
+        ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], ct[T18], ct[T19], ct[T20], ct[T21], ct[T22]))
   }
 
   /**

--- a/src/main/scala/shark/SharkServer.scala
+++ b/src/main/scala/shark/SharkServer.scala
@@ -28,7 +28,8 @@ import java.util.Properties
 import java.util.concurrent.CountDownLatch
 
 import scala.annotation.tailrec
-import scala.concurrent.ops.spawn
+import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import org.apache.commons.logging.LogFactory
 import org.apache.commons.cli.OptionBuilder
@@ -93,7 +94,7 @@ object SharkServer extends LogHelper {
         var remoteClient = "Unknown"
 
         // Seed session ID by a random number
-        var sessionID = scala.Math.round(scala.Math.random * 10000000).toString
+        var sessionID = scala.math.round(scala.math.random * 10000000).toString
         var jdbcSocket: java.net.Socket = null
         if (t.isInstanceOf[TSocket]) {
           remoteClient = t.asInstanceOf[TSocket].getSocket()
@@ -164,7 +165,7 @@ object SharkServer extends LogHelper {
   private def execLoadRdds(loadFlag: Boolean, latch:CountDownLatch) {
     if (!loadFlag) {
       latch.countDown
-    } else spawn {
+    } else future {
       while (!server.isServing()) {}
       try {
         val sshandler = new SharkServerHandler

--- a/src/main/scala/shark/api/DataTypes.java
+++ b/src/main/scala/shark/api/DataTypes.java
@@ -22,8 +22,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.sql.Timestamp;
 
-import scala.reflect.ClassManifest;
-import scala.reflect.ClassManifest$;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
 
 import org.apache.hadoop.hive.serde.Constants;
 
@@ -107,34 +107,30 @@ public class DataTypes {
     }
   }
 
-  public static DataType fromManifest(ClassManifest<?> m) throws UnknownDataTypeException {
-    if (m.equals(m(Boolean.class)) || m.equals(ClassManifest$.MODULE$.Boolean())) {
-      return INT;
-    } else if (m.equals(m(Byte.class)) || m.equals(ClassManifest$.MODULE$.Byte())) {
-      return TINYINT;
-    } else if (m.equals(m(Short.class)) || m.equals(ClassManifest$.MODULE$.Short())) {
-      return SMALLINT;
-    } else if (m.equals(m(Integer.class)) || m.equals(ClassManifest$.MODULE$.Int())) {
-      return INT;
-    } else if (m.equals(m(Long.class)) || m.equals(ClassManifest$.MODULE$.Long())) {
-      return BIGINT;
-    } else if (m.equals(m(Float.class)) || m.equals(ClassManifest$.MODULE$.Float())) {
-      return FLOAT;
-    } else if (m.equals(m(Double.class)) || m.equals(ClassManifest$.MODULE$.Double())) {
-      return DOUBLE;
-    } else if (m.equals(m(String.class))) {
-      return STRING;
-    } else if (m.equals(m(Timestamp.class))) {
-      return TIMESTAMP;
-    } else if (m.equals(m(Date.class))) {
-      return DATE;
+  public static DataType fromClassTag(ClassTag<?> m) throws UnknownDataTypeException {
+    if (m.equals(ClassTag$.MODULE$.Boolean())) {
+        return INT;
+    } else if (m.equals(ClassTag$.MODULE$.Byte())){
+        return TINYINT;
+    } else if (m.equals(ClassTag$.MODULE$.Short())) {
+        return SMALLINT;
+    } else if (m.equals(ClassTag$.MODULE$.Int())) {
+        return INT;
+    } else if (m.equals(ClassTag$.MODULE$.Long())) {
+        return BIGINT;
+    } else if (m.equals(ClassTag$.MODULE$.Float())) {
+        return FLOAT;
+    } else if (m.equals(ClassTag$.MODULE$.Double())) {
+        return DOUBLE;
+    } else if (m.equals(ClassTag$.MODULE$.apply(String.class))) {
+        return STRING;
+    } else if (m.equals(ClassTag$.MODULE$.apply(Timestamp.class))) {
+        return TIMESTAMP;
+    } else if (m.equals(ClassTag$.MODULE$.apply(Date.class))) {
+        return DATE;
     } else {
-      throw new UnknownDataTypeException(m.toString());
+        throw new UnknownDataTypeException(m.toString());
     }
     // TODO: binary data type.
-  }
-
-  private static <T> ClassManifest<T> m(Class<T> cls) {
-    return ClassManifest$.MODULE$.fromClass(cls);
   }
 }

--- a/src/main/scala/shark/api/JavaTableRDD.scala
+++ b/src/main/scala/shark/api/JavaTableRDD.scala
@@ -17,6 +17,8 @@
 
 package shark.api
 
+import scala.reflect.ClassTag
+
 import org.apache.spark.api.java.function.{Function => JFunction}
 import org.apache.spark.api.java.JavaRDDLike
 import org.apache.spark.rdd.RDD
@@ -29,7 +31,7 @@ class JavaTableRDD(val rdd: RDD[Row], val schema: Array[ColumnDesc])
   override def wrapRDD(rdd: RDD[Row]): JavaTableRDD = new JavaTableRDD(rdd, schema)
 
   // Common RDD functions
-  override val classManifest: ClassManifest[Row] = implicitly[ClassManifest[Row]]
+  override val classTag: ClassTag[Row] = implicitly[ClassTag[Row]]
 
   // This shouldn't be necessary, but we seem to need this to get first() to return Row
   // instead of Object; possibly a compiler bug?

--- a/src/main/scala/shark/api/RDDTable.scala
+++ b/src/main/scala/shark/api/RDDTable.scala
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2012 The Regents of The University California.
  * All rights reserved.
@@ -17,116 +18,119 @@
 
 package shark.api
 
-// *** This file is auto-generated from rddtable_generator.py ***
+// *** This file is auto-generated from RDDTable_generator.py ***
+
+import scala.language.implicitConversions
 
 import org.apache.spark.rdd.RDD
+import scala.reflect.ClassTag
 
 object RDDTableImplicits {
-  private type M[T] = ClassManifest[T]
+  private type C[T] = ClassTag[T]
 
 
-  implicit def rddToTable2[T1: M, T2: M]
+  implicit def rddToTable2[T1: C, T2: C]
   (rdd: RDD[(T1, T2)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable3[T1: M, T2: M, T3: M]
+  implicit def rddToTable3[T1: C, T2: C, T3: C]
   (rdd: RDD[(T1, T2, T3)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable4[T1: M, T2: M, T3: M, T4: M]
+  implicit def rddToTable4[T1: C, T2: C, T3: C, T4: C]
   (rdd: RDD[(T1, T2, T3, T4)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable5[T1: M, T2: M, T3: M, T4: M, T5: M]
+  implicit def rddToTable5[T1: C, T2: C, T3: C, T4: C, T5: C]
   (rdd: RDD[(T1, T2, T3, T4, T5)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable6[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M]
+  implicit def rddToTable6[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable7[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M]
+  implicit def rddToTable7[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable8[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M]
+  implicit def rddToTable8[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable9[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M]
+  implicit def rddToTable9[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable10[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M]
+  implicit def rddToTable10[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable11[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M]
+  implicit def rddToTable11[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable12[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M]
+  implicit def rddToTable12[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable13[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M]
+  implicit def rddToTable13[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable14[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M]
+  implicit def rddToTable14[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable15[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M]
+  implicit def rddToTable15[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable16[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M]
+  implicit def rddToTable16[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable17[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  implicit def rddToTable17[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable18[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  implicit def rddToTable18[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable19[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  implicit def rddToTable19[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable20[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M,
-  T20: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  implicit def rddToTable20[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, 
+    T20: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19, T20)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable21[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M,
-  T20: M, T21: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  implicit def rddToTable21[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, 
+    T20: C, T21: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19, T20, T21)]): RDDTableFunctions = RDDTable(rdd)
 
 
-  implicit def rddToTable22[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M,
-  T20: M, T21: M, T22: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  implicit def rddToTable22[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, 
+    T20: C, T21: C, T22: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19, T20, T21, T22)]): RDDTableFunctions = RDDTable(rdd)
 
 
@@ -134,210 +138,213 @@ object RDDTableImplicits {
 
 object RDDTable {
 
-  private type M[T] = ClassManifest[T]
-  private def m[T](implicit m : ClassManifest[T]) = classManifest[T](m)
+  private type C[T] = ClassTag[T]
+  private def ct[T](implicit c : ClassTag[T]) = c
 
-  def apply[T1: M, T2: M]
+  def apply[T1: C, T2: C]
   (rdd: RDD[(T1, T2)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M]
+  def apply[T1: C, T2: C, T3: C]
   (rdd: RDD[(T1, T2, T3)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M]
+  def apply[T1: C, T2: C, T3: C, T4: C]
   (rdd: RDD[(T1, T2, T3, T4)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C]
   (rdd: RDD[(T1, T2, T3, T4, T5)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M]
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C]
   (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15], m[T16]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15], ct[T16]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15], m[T16], m[T17]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15], ct[T16], ct[T17]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15], m[T16], m[T17], m[T18]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], 
+    ct[T18]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], 
+    ct[T18], ct[T19]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M,
-  T20: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, 
+    T20: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19, T20)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19],
-      m[T20]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], 
+    ct[T18], ct[T19], ct[T20]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M,
-  T20: M, T21: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, 
+    T20: C, T21: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19, T20, T21)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19],
-      m[T20], m[T21]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], 
+    ct[T18], ct[T19], ct[T20], ct[T21]))
   }
 
 
-  def apply[T1: M, T2: M, T3: M, T4: M, T5: M, T6: M, T7: M, T8: M, T9: M, T10: M,
-  T11: M, T12: M, T13: M, T14: M, T15: M, T16: M, T17: M, T18: M, T19: M,
-  T20: M, T21: M, T22: M]
-  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16,
+  def apply[T1: C, T2: C, T3: C, T4: C, T5: C, T6: C, T7: C, T8: C, T9: C, T10: C, 
+    T11: C, T12: C, T13: C, T14: C, T15: C, T16: C, T17: C, T18: C, T19: C, 
+    T20: C, T21: C, T22: C]
+  (rdd: RDD[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
     T17, T18, T19, T20, T21, T22)]) = {
-    val cm = implicitly[Manifest[Seq[Any]]]
-    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(cm)
-    new RDDTableFunctions(rddSeq, Seq(m[T1], m[T2], m[T3], m[T4], m[T5], m[T6], m[T7], m[T8], m[T9], m[T10],
-      m[T11], m[T12], m[T13], m[T14], m[T15], m[T16], m[T17], m[T18], m[T19],
-      m[T20], m[T21], m[T22]))
+    val classTag = implicitly[ClassTag[Seq[Any]]]
+    val rddSeq: RDD[Seq[_]] = rdd.map(t => t.productIterator.toList.asInstanceOf[Seq[Any]])(classTag)
+    new RDDTableFunctions(rddSeq, Seq(ct[T1], ct[T2], ct[T3], ct[T4], ct[T5], ct[T6], ct[T7], ct[T8], ct[T9], 
+    ct[T10], ct[T11], ct[T12], ct[T13], ct[T14], ct[T15], ct[T16], ct[T17], 
+    ct[T18], ct[T19], ct[T20], ct[T21], ct[T22]))
   }
 
 }

--- a/src/main/scala/shark/api/TableRDDGenerated.scala
+++ b/src/main/scala/shark/api/TableRDDGenerated.scala
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2013 The Regents of The University California.
  * All rights reserved.
@@ -24,6 +25,8 @@ package shark.api
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{TaskContext, Partition}
 
+import scala.reflect.ClassTag
+
 class TableSeqRDD(prev: TableRDD)
   extends RDD[Seq[Any]](prev) {
 
@@ -39,167 +42,167 @@ class TableSeqRDD(prev: TableRDD)
 
 
 class TableRDD1[T1](prev: TableRDD,
-                    mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple1[T1]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 1, "Table only has " + tableCols + " columns, expecting 1")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple1[T1]] = {
     prev.compute(split, context).map( row =>
       new Tuple1[T1](
-        row.getPrimitiveGeneric[T1](0) ) )
+                row.getPrimitiveGeneric[T1](0) ) )
 
   }
 }
 
 class TableRDD2[T1, T2](prev: TableRDD,
-                        mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple2[T1, T2]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 2, "Table only has " + tableCols + " columns, expecting 2")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple2[T1, T2]] = {
     prev.compute(split, context).map( row =>
       new Tuple2[T1, T2](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1) ) )
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1) ) )
 
   }
 }
 
 class TableRDD3[T1, T2, T3](prev: TableRDD,
-                            mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple3[T1, T2, T3]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 3, "Table only has " + tableCols + " columns, expecting 3")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple3[T1, T2, T3]] = {
     prev.compute(split, context).map( row =>
       new Tuple3[T1, T2, T3](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2)
-      ) )
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2)
+ ) )
 
   }
 }
 
 class TableRDD4[T1, T2, T3, T4](prev: TableRDD,
-                                mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple4[T1, T2, T3, T4]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 4, "Table only has " + tableCols + " columns, expecting 4")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple4[T1, T2, T3, T4]] = {
     prev.compute(split, context).map( row =>
       new Tuple4[T1, T2, T3, T4](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3) ) )
 
   }
 }
 
 class TableRDD5[T1, T2, T3, T4, T5](prev: TableRDD,
-                                    mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple5[T1, T2, T3, T4, T5]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 5, "Table only has " + tableCols + " columns, expecting 5")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple5[T1, T2, T3, T4, T5]] = {
     prev.compute(split, context).map( row =>
       new Tuple5[T1, T2, T3, T4, T5](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4) ) )
 
   }
 }
 
 class TableRDD6[T1, T2, T3, T4, T5, T6](prev: TableRDD,
-                                        mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple6[T1, T2, T3, T4, T5, T6]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 6, "Table only has " + tableCols + " columns, expecting 6")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple6[T1, T2, T3, T4, T5, T6]] = {
     prev.compute(split, context).map( row =>
       new Tuple6[T1, T2, T3, T4, T5, T6](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5)
-      ) )
+ ) )
 
   }
 }
 
 class TableRDD7[T1, T2, T3, T4, T5, T6, T7](prev: TableRDD,
-                                            mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple7[T1, T2, T3, T4, T5, T6, T7]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 7, "Table only has " + tableCols + " columns, expecting 7")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple7[T1, T2, T3, T4, T5, T6, T7]] = {
     prev.compute(split, context).map( row =>
       new Tuple7[T1, T2, T3, T4, T5, T6, T7](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6) ) )
 
@@ -207,24 +210,24 @@ class TableRDD7[T1, T2, T3, T4, T5, T6, T7](prev: TableRDD,
 }
 
 class TableRDD8[T1, T2, T3, T4, T5, T6, T7, T8](prev: TableRDD,
-                                                mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 8, "Table only has " + tableCols + " columns, expecting 8")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]] = {
     prev.compute(split, context).map( row =>
       new Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7) ) )
 
@@ -232,50 +235,50 @@ class TableRDD8[T1, T2, T3, T4, T5, T6, T7, T8](prev: TableRDD,
 }
 
 class TableRDD9[T1, T2, T3, T4, T5, T6, T7, T8, T9](prev: TableRDD,
-                                                    mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 9, "Table only has " + tableCols + " columns, expecting 9")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]] = {
     prev.compute(split, context).map( row =>
       new Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8)
-      ) )
+ ) )
 
   }
 }
 
 class TableRDD10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](prev: TableRDD,
-                                                          mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 10, "Table only has " + tableCols + " columns, expecting 10")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]] = {
     prev.compute(split, context).map( row =>
       new Tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9) ) )
@@ -284,24 +287,24 @@ class TableRDD10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](prev: TableRDD,
 }
 
 class TableRDD11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](prev: TableRDD,
-                                                               mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 11, "Table only has " + tableCols + " columns, expecting 11")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]] = {
     prev.compute(split, context).map( row =>
       new Tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10) ) )
@@ -310,51 +313,51 @@ class TableRDD11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](prev: TableRDD,
 }
 
 class TableRDD12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](prev: TableRDD,
-                                                                    mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 12, "Table only has " + tableCols + " columns, expecting 12")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]] = {
     prev.compute(split, context).map( row =>
       new Tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11)
-      ) )
+ ) )
 
   }
 }
 
 class TableRDD13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](prev: TableRDD,
-                                                                         mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 13, "Table only has " + tableCols + " columns, expecting 13")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]] = {
     prev.compute(split, context).map( row =>
       new Tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
@@ -364,24 +367,24 @@ class TableRDD13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](prev: T
 }
 
 class TableRDD14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](prev: TableRDD,
-                                                                              mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 14, "Table only has " + tableCols + " columns, expecting 14")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]] = {
     prev.compute(split, context).map( row =>
       new Tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
@@ -391,52 +394,52 @@ class TableRDD14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](pr
 }
 
 class TableRDD15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](prev: TableRDD,
-                                                                                   mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 15, "Table only has " + tableCols + " columns, expecting 15")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]] = {
     prev.compute(split, context).map( row =>
       new Tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
         row.getPrimitiveGeneric[T13](12), row.getPrimitiveGeneric[T14](13), row.getPrimitiveGeneric[T15](14)
-      ) )
+ ) )
 
   }
 }
 
 class TableRDD16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](prev: TableRDD,
-                                                                                        mans: Seq[ClassManifest[_]])
+                          tags: Seq[ClassTag[_]])
   extends RDD[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 16, "Table only has " + tableCols + " columns, expecting 16")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
+  override def compute(split: Partition, context: TaskContext): 
   Iterator[Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]] = {
     prev.compute(split, context).map( row =>
       new Tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
@@ -446,25 +449,29 @@ class TableRDD16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T1
   }
 }
 
-class TableRDD17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](prev: TableRDD,
-                                                                                             mans: Seq[ClassManifest[_]])
-  extends RDD[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]](prev) {
+class TableRDD17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17](prev: TableRDD,
+                          tags: Seq[ClassTag[_]])
+  extends RDD[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 17, "Table only has " + tableCols + " columns, expecting 17")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
-  Iterator[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]] = {
+  override def compute(split: Partition, context: TaskContext): 
+  Iterator[Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17]] = {
     prev.compute(split, context).map( row =>
-      new Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+      new Tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17](
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
@@ -474,58 +481,62 @@ class TableRDD17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T1
   }
 }
 
-class TableRDD18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](prev: TableRDD,
-                                                                                                  mans: Seq[ClassManifest[_]])
-  extends RDD[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]](prev) {
+class TableRDD18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18](prev: TableRDD,
+                          tags: Seq[ClassTag[_]])
+  extends RDD[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 18, "Table only has " + tableCols + " columns, expecting 18")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
-  Iterator[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]] = {
+  override def compute(split: Partition, context: TaskContext): 
+  Iterator[Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18]] = {
     prev.compute(split, context).map( row =>
-      new Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+      new Tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18](
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
         row.getPrimitiveGeneric[T13](12), row.getPrimitiveGeneric[T14](13), row.getPrimitiveGeneric[T15](14),
         row.getPrimitiveGeneric[T16](15), row.getPrimitiveGeneric[T17](16), row.getPrimitiveGeneric[T18](17)
-      ) )
+ ) )
 
   }
 }
 
-class TableRDD19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-T19](prev: TableRDD,
-     mans: Seq[ClassManifest[_]])
-  extends RDD[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19]](prev) {
+class TableRDD19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19](prev: TableRDD,
+                          tags: Seq[ClassTag[_]])
+  extends RDD[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 19, "Table only has " + tableCols + " columns, expecting 19")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
-  Iterator[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19]] = {
+  override def compute(split: Partition, context: TaskContext): 
+  Iterator[Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19]] = {
     prev.compute(split, context).map( row =>
-      new Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-        T19](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+      new Tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19](
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
@@ -536,29 +547,29 @@ T19](prev: TableRDD,
   }
 }
 
-class TableRDD20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-T19, T20](prev: TableRDD,
-          mans: Seq[ClassManifest[_]])
-  extends RDD[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19, T20]](prev) {
+class TableRDD20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20](prev: TableRDD,
+                          tags: Seq[ClassTag[_]])
+  extends RDD[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 20, "Table only has " + tableCols + " columns, expecting 20")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
-  Iterator[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19, T20]] = {
+  override def compute(split: Partition, context: TaskContext): 
+  Iterator[Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20]] = {
     prev.compute(split, context).map( row =>
-      new Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-        T19, T20](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+      new Tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20](
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
@@ -569,63 +580,63 @@ T19, T20](prev: TableRDD,
   }
 }
 
-class TableRDD21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-T19, T20, T21](prev: TableRDD,
-               mans: Seq[ClassManifest[_]])
-  extends RDD[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19, T20, T21]](prev) {
+class TableRDD21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21](prev: TableRDD,
+                          tags: Seq[ClassTag[_]])
+  extends RDD[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 21, "Table only has " + tableCols + " columns, expecting 21")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
-  Iterator[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19, T20, T21]] = {
+  override def compute(split: Partition, context: TaskContext): 
+  Iterator[Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21]] = {
     prev.compute(split, context).map( row =>
-      new Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-        T19, T20, T21](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+      new Tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21](
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),
         row.getPrimitiveGeneric[T13](12), row.getPrimitiveGeneric[T14](13), row.getPrimitiveGeneric[T15](14),
         row.getPrimitiveGeneric[T16](15), row.getPrimitiveGeneric[T17](16), row.getPrimitiveGeneric[T18](17),
         row.getPrimitiveGeneric[T19](18), row.getPrimitiveGeneric[T20](19), row.getPrimitiveGeneric[T21](20)
-      ) )
+ ) )
 
   }
 }
 
-class TableRDD22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-T19, T20, T21, T22](prev: TableRDD,
-                    mans: Seq[ClassManifest[_]])
-  extends RDD[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19, T20, T21, T22]](prev) {
+class TableRDD22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21, T22](prev: TableRDD,
+                          tags: Seq[ClassTag[_]])
+  extends RDD[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21, T22]](prev) {
   def schema = prev.schema
 
   private val tableCols = schema.size
   require(tableCols == 22, "Table only has " + tableCols + " columns, expecting 22")
 
-  mans.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromManifest(m) != schema(i).dataType)
+  tags.zipWithIndex.foreach{ case (m, i) => if (DataTypes.fromClassTag(m) != schema(i).dataType)
     throw new IllegalArgumentException(
-      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromManifest(m) + " got " + schema(i).dataType) }
+      "Type mismatch on column " + (i + 1) + ", expected " + DataTypes.fromClassTag(m) + " got " + schema(i).dataType) }
 
   override def getPartitions = prev.getPartitions
 
-  override def compute(split: Partition, context: TaskContext):
-  Iterator[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-    T19, T20, T21, T22]] = {
+  override def compute(split: Partition, context: TaskContext): 
+  Iterator[Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21, T22]] = {
     prev.compute(split, context).map( row =>
-      new Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-        T19, T20, T21, T22](
-        row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
+      new Tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, 
+    T17, T18, T19, T20, T21, T22](
+                row.getPrimitiveGeneric[T1](0), row.getPrimitiveGeneric[T2](1), row.getPrimitiveGeneric[T3](2),
         row.getPrimitiveGeneric[T4](3), row.getPrimitiveGeneric[T5](4), row.getPrimitiveGeneric[T6](5),
         row.getPrimitiveGeneric[T7](6), row.getPrimitiveGeneric[T8](7), row.getPrimitiveGeneric[T9](8),
         row.getPrimitiveGeneric[T10](9), row.getPrimitiveGeneric[T11](10), row.getPrimitiveGeneric[T12](11),

--- a/src/main/scala/shark/execution/CoGroupedRDD.scala
+++ b/src/main/scala/shark/execution/CoGroupedRDD.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark
 
+import scala.language.existentials
+
 import java.io.{ObjectOutputStream, IOException}
 import java.util.{HashMap => JHashMap}
 

--- a/src/main/scala/shark/execution/CommonJoinOperator.scala
+++ b/src/main/scala/shark/execution/CommonJoinOperator.scala
@@ -19,7 +19,8 @@ package shark.execution
 
 import java.util.{HashMap => JavaHashMap, List => JavaList, ArrayList =>JavaArrayList}
 
-import scala.reflect.BeanProperty
+import scala.beans.BeanProperty
+import scala.reflect.ClassTag
 
 import org.apache.hadoop.hive.ql.exec.ExprNodeEvaluator
 import org.apache.hadoop.hive.ql.exec.{JoinUtil => HiveJoinUtil}
@@ -102,7 +103,7 @@ abstract class CommonJoinOperator[T <: JoinDesc] extends NaryOperator[T] {
 }
 
 
-class CartesianProduct[T >: Null : ClassManifest](val numTables: Int) {
+class CartesianProduct[T >: Null : ClassTag](val numTables: Int) {
 
   val SINGLE_NULL_LIST = Seq[T](null)
   val EMPTY_LIST = Seq[T]()

--- a/src/main/scala/shark/execution/HadoopTableReader.scala
+++ b/src/main/scala/shark/execution/HadoopTableReader.scala
@@ -149,6 +149,7 @@ class HadoopTableReader(@transient _tableDesc: TableDesc, @transient _localHConf
       // Create local references so that the outer object isn't serialized.
       val tableDesc = _tableDesc
       val broadcastedHiveConf = _broadcastedHiveConf
+      val localDeserializer = partDeserializer
 
       val hivePartitionRDD = createHadoopRdd(tableDesc, inputPathStr, ifc)
       hivePartitionRDD.mapPartitions { iter =>
@@ -156,7 +157,7 @@ class HadoopTableReader(@transient _tableDesc: TableDesc, @transient _localHConf
         val rowWithPartArr = new Array[Object](2)
         // Map each tuple to a row object
         iter.map { value =>
-          val deserializer = partDeserializer.newInstance()
+          val deserializer = localDeserializer.newInstance()
           deserializer.initialize(hconf, partProps)
           val deserializedRow = deserializer.deserialize(value) // LazyStruct
           rowWithPartArr.update(0, deserializedRow)

--- a/src/main/scala/shark/execution/Operator.scala
+++ b/src/main/scala/shark/execution/Operator.scala
@@ -17,6 +17,8 @@
 
 package shark.execution
 
+import scala.language.existentials
+
 import java.util.{List => JavaList}
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConversions._

--- a/src/main/scala/shark/execution/RDDUtils.scala
+++ b/src/main/scala/shark/execution/RDDUtils.scala
@@ -18,6 +18,7 @@
 package shark.execution
 
 import scala.collection.JavaConversions
+import scala.reflect.ClassTag
 
 import com.google.common.collect.{Ordering => GOrdering}
 
@@ -37,7 +38,7 @@ object RDDUtils {
    * Returns a UnionRDD using both RDD arguments. Any UnionRDD argument is "flattened", in that
    * its parent sequence of RDDs is directly passed to the UnionRDD returned.
    */
-  def unionAndFlatten[T: ClassManifest](
+  def unionAndFlatten[T: ClassTag](
     rdd: RDD[T],
     otherRdd: RDD[T]): UnionRDD[T] = {
     val otherRdds: Seq[RDD[T]] = otherRdd match {
@@ -72,7 +73,7 @@ object RDDUtils {
    * Repartition an RDD using the given partitioner. This is similar to Spark's partitionBy,
    * except we use the Shark shuffle serializer.
    */
-  def repartition[K: ClassManifest, V: ClassManifest](rdd: RDD[(K, V)], part: Partitioner)
+  def repartition[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)], part: Partitioner)
     : RDD[(K, V)] =
   {
     new ShuffledRDD[K, V, (K, V)](rdd, part).setSerializer(SharkEnv.shuffleSerializerName)
@@ -82,7 +83,7 @@ object RDDUtils {
    * Sort the RDD by key. This is similar to Spark's sortByKey, except that we use
    * the Shark shuffle serializer.
    */
-  def sortByKey[K <: Comparable[K]: ClassManifest, V: ClassManifest](rdd: RDD[(K, V)])
+  def sortByKey[K <: Comparable[K]: ClassTag, V: ClassTag](rdd: RDD[(K, V)])
     : RDD[(K, V)] =
   {
     val part = new RangePartitioner(rdd.partitions.length, rdd)
@@ -97,7 +98,7 @@ object RDDUtils {
   /**
    * Return an RDD containing the top K (K smallest key) from the given RDD.
    */
-  def topK[K <: Comparable[K]: ClassManifest, V: ClassManifest](rdd: RDD[(K, V)], k: Int)
+  def topK[K <: Comparable[K]: ClassTag, V: ClassTag](rdd: RDD[(K, V)], k: Int)
     : RDD[(K, V)] =
   {
     // First take top K on each partition.
@@ -109,7 +110,7 @@ object RDDUtils {
   /**
    * Take top K on each partition and return a new RDD.
    */
-  def partitionTopK[K <: Comparable[K]: ClassManifest, V: ClassManifest](
+  def partitionTopK[K <: Comparable[K]: ClassTag, V: ClassTag](
     rdd: RDD[(K, V)], k: Int): RDD[(K, V)] = {
     rdd.mapPartitions(iter => topK(iter, k))
   }
@@ -117,7 +118,7 @@ object RDDUtils {
   /**
    * Return top K elements out of an iterator.
    */
-  private def topK[K <: Comparable[K]: ClassManifest, V: ClassManifest](
+  private def topK[K <: Comparable[K]: ClassTag, V: ClassTag](
     it: Iterator[(K, V)], k: Int): Iterator[(K, V)]  = {
     val ordering = new GOrdering[(K,V)] {
       override def compare(l: (K, V), r: (K, V)) = {

--- a/src/main/scala/shark/execution/SparkLoadTask.scala
+++ b/src/main/scala/shark/execution/SparkLoadTask.scala
@@ -153,8 +153,9 @@ class SparkLoadTask extends HiveTask[SparkLoadWork] with Serializable with LogHe
     val databaseName = work.databaseName
     val tableName = work.tableName
     // Set Spark's job description to be this query.
-    SharkEnv.sc.setJobDescription("Updating table %s.%s for a(n) %s"
-      .format(databaseName, tableName, work.commandType))
+    SharkEnv.sc.setJobGroup(
+      "shark.job",
+      s"Updating table $databaseName.$tableName for a(n) ${work.commandType}")
     val hiveTable = Hive.get(conf).getTable(databaseName, tableName)
     // Use HadoopTableReader to help with table scans. The `conf` passed is reused across HadoopRDD
     // instantiations. 

--- a/src/main/scala/shark/execution/SparkTask.scala
+++ b/src/main/scala/shark/execution/SparkTask.scala
@@ -89,7 +89,7 @@ class SparkTask extends HiveTask[SparkWork] with Serializable with LogHelper {
     terminalOp.initializeMasterOnAll()
 
     // Set Spark's job description to be this query.
-    SharkEnv.sc.setJobDescription(work.pctx.getContext.getCmd)
+    SharkEnv.sc.setJobGroup("shark.job", work.pctx.getContext.getCmd)
 
     // Set the fair scheduler's pool using mapred.fairscheduler.pool if it is defined.
     Option(conf.get("mapred.fairscheduler.pool")).foreach { pool =>

--- a/src/main/scala/shark/execution/package.scala
+++ b/src/main/scala/shark/execution/package.scala
@@ -17,9 +17,10 @@
 
 package shark
 
+import scala.language.implicitConversions
+
 import shark.execution.serialization.KryoSerializationWrapper
 import shark.execution.serialization.OperatorSerializationWrapper
-
 
 package object execution {
 

--- a/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
+++ b/src/main/scala/shark/memstore2/MemoryMetadataManager.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.{HashMap=> JavaHashMap, Map => JavaMap}
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable.ConcurrentMap
+import scala.collection.concurrent
 
 import org.apache.hadoop.hive.ql.metadata.Hive
 
@@ -34,13 +34,13 @@ import shark.util.HiveUtils
 class MemoryMetadataManager {
 
   // Set of tables, from databaseName.tableName to Table object.
-  private val _tables: ConcurrentMap[String, Table] =
+  private val _tables: concurrent.Map[String, Table] =
     new ConcurrentHashMap[String, Table]()
 
   // TODO(harvey): Support stats for Hive-partitioned tables.
   // Set of stats, from databaseName.tableName to the stats. This is guaranteed to have the same
   // structure / size as the _tables map.
-  private val _keyToStats: ConcurrentMap[String, collection.Map[Int, TablePartitionStats]] =
+  private val _keyToStats: concurrent.Map[String, collection.Map[Int, TablePartitionStats]] =
     new ConcurrentHashMap[String, collection.Map[Int, TablePartitionStats]]
 
   def putStats(

--- a/src/main/scala/shark/memstore2/PartitionedMemoryTable.scala
+++ b/src/main/scala/shark/memstore2/PartitionedMemoryTable.scala
@@ -20,7 +20,7 @@ package shark.memstore2
 import java.util.concurrent.{ConcurrentHashMap => ConcurrentJavaHashMap}
 
 import scala.collection.JavaConversions._
-import scala.collection.mutable.ConcurrentMap
+import scala.collection.concurrent
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -54,7 +54,7 @@ class PartitionedMemoryTable(
   // A map from the Hive-partition key to the RDD that contains contents of that partition.
   // The conventional string format for the partition key, 'col1=value1/col2=value2/...', can be
   // computed using MemoryMetadataManager#makeHivePartitionKeyStr()
-  private val _keyToPartitions: ConcurrentMap[String, RDDValue] =
+  private val _keyToPartitions: concurrent.Map[String, RDDValue] =
     new ConcurrentJavaHashMap[String, RDDValue]()
 
   // The eviction policy for this table's cached Hive-partitions. An example of how this

--- a/src/main/scala/shark/memstore2/column/ColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnIterator.scala
@@ -17,8 +17,9 @@
 
 package shark.memstore2.column
 
-import java.nio.{ByteBuffer, ByteOrder}
+import scala.language.implicitConversions
 
+import java.nio.{ByteBuffer, ByteOrder}
 
 trait ColumnIterator {
 

--- a/src/main/scala/shark/memstore2/column/ColumnType.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnType.scala
@@ -20,6 +20,8 @@ package shark.memstore2.column
 import java.nio.ByteBuffer
 import java.sql.Timestamp
 
+import scala.reflect.ClassTag
+
 import org.apache.hadoop.hive.serde2.ByteStream
 import org.apache.hadoop.hive.serde2.`lazy`.{ByteArrayRef, LazyBinary}
 import org.apache.hadoop.hive.serde2.io.ByteWritable
@@ -37,19 +39,18 @@ import org.apache.hadoop.io._
  * @tparam T Scala data type for the column.
  * @tparam V Writable data type for the column.
  */
-sealed abstract class ColumnType[T : ClassManifest, V : ClassManifest](
+sealed abstract class ColumnType[T : ClassTag, V : ClassTag](
     val typeID: Int, val defaultSize: Int) {
 
   /**
-   * Scala class manifest. Can be used to create primitive arrays and hash tables.
+   * Scala ClassTag. Can be used to create primitive arrays and hash tables.
    */
-  def scalaManifest: ClassManifest[T] = classManifest[T]
+  def scalaTag = implicitly[ClassTag[T]]
 
   /**
-   * Scala class manifest for the writable type. Can be used to create primitive arrays and
-   * hash tables.
+   * Scala ClassTag. Can be used to create primitive arrays and hash tables.
    */
-  def writableManifest: ClassManifest[V] = classManifest[V]
+  def writableScalaTag = implicitly[ClassTag[V]]
 
   /**
    * Extract a value out of the buffer at the buffer's current position.

--- a/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
@@ -108,7 +108,7 @@ class DictDecoder[V](buffer: ByteBuffer, columnType: ColumnType[_, V]) extends I
   // decompressed value.
   private val _dictionary: Array[V] =  {
     val size = buffer.getInt()
-    val arr = columnType.writableManifest.newArray(size)
+    val arr = columnType.writableScalaTag.newArray(size)
     var count = 0
     while (count < size) {
       val writable = columnType.newWritable()

--- a/src/main/scala/shark/util/HiveUtils.scala
+++ b/src/main/scala/shark/util/HiveUtils.scala
@@ -21,6 +21,7 @@ import java.util.{Arrays => JavaArrays, ArrayList => JavaArrayList}
 import java.util.{HashSet => JHashSet}
 import java.util.Properties
 
+import scala.reflect.ClassTag
 import scala.collection.JavaConversions._
 
 import org.apache.hadoop.hive.conf.HiveConf
@@ -43,8 +44,8 @@ import shark.memstore2.SharkTblProperties
 
 private[shark] object HiveUtils {
 
-  def getJavaPrimitiveObjectInspector(m: ClassManifest[_]): PrimitiveObjectInspector = {
-    getJavaPrimitiveObjectInspector(DataTypes.fromManifest(m))
+  def getJavaPrimitiveObjectInspector(c: ClassTag[_]): PrimitiveObjectInspector = {
+    getJavaPrimitiveObjectInspector(DataTypes.fromClassTag(c))
   }
 
   def getJavaPrimitiveObjectInspector(t: DataType): PrimitiveObjectInspector = t match {
@@ -89,10 +90,10 @@ private[shark] object HiveUtils {
   def createTableInHive(
       tableName: String,
       columnNames: Seq[String],
-      columnTypes: Seq[ClassManifest[_]],
+      columnTypes: Seq[ClassTag[_]],
       hiveConf: HiveConf = new HiveConf): Boolean = {
-    val schema = columnNames.zip(columnTypes).map { case (colName, manifest) =>
-      new FieldSchema(colName, DataTypes.fromManifest(manifest).hiveName, "")
+    val schema = columnNames.zip(columnTypes).map { case (colName, classTag) =>
+      new FieldSchema(colName, DataTypes.fromClassTag(classTag).hiveName, "")
     }
 
     // Setup the create table descriptor with necessary information.

--- a/src/test/scala/shark/SharkServerSuite.scala
+++ b/src/test/scala/shark/SharkServerSuite.scala
@@ -10,7 +10,8 @@ import scala.collection.JavaConversions._
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.scalatest.matchers.ShouldMatchers
 
-import scala.concurrent.ops._
+import scala.concurrent._
+import ExecutionContext.Implicits.global
 
 /**
  * Test for the Shark server.
@@ -57,7 +58,7 @@ class SharkServerSuite extends FunSuite with BeforeAndAfterAll with ShouldMatche
     // Spawn a thread to read the output from the forked process.
     // Note that this is necessary since in some configurations, log4j could be blocked
     // if its output to stderr are not read, and eventually blocking the entire test suite.
-    spawn {
+    future {
       while (true) {
         val stdout = readFrom(inputReader)
         val stderr = readFrom(errorReader)

--- a/src/test/scala/shark/SharkServerSuite.scala
+++ b/src/test/scala/shark/SharkServerSuite.scala
@@ -79,6 +79,7 @@ class SharkServerSuite extends FunSuite with BeforeAndAfterAll with ShouldMatche
   }
 
   test("test query execution against a shark server") {
+    Thread.sleep(5*1000) // I know... Gross.  However, without this the tests fail non-deterministically.
 
     val dataFilePath = TestUtils.dataFilePath + "/kv1.txt"
     val stmt = createStatement()


### PR DESCRIPTION
- Replace ClassManifests with ClassTags
- Denote use of language features (implicits, existencials)
- Stop using deprecated ConcurrentMap and spawn.
- Stop using deprecated spark setJobDescription.
- Avoid catching all Throwables in favor of catching Exception.
