### PR TITLE
Add -nc to wget to avoid it "not clobber" (or download a *.n version of) the file if it already exists.

### DIFF
--- a/bin/dev/run-tests-from-scratch
+++ b/bin/dev/run-tests-from-scratch
@@ -226,7 +226,7 @@ fi
 # Download Scala if SCALA_HOME is not specified.
 ####################################################################
 if [ "x$SCALA_HOME" == "x" ] ; then
-  wget $SCALA_DOWNLOAD_PATH
+  wget -nc $SCALA_DOWNLOAD_PATH
   tar xvfz scala*tgz
   export SCALA_HOME="$WORKSPACE/scala-$SCALA_VERSION"
 fi

--- a/bin/dev/run-tests-from-scratch
+++ b/bin/dev/run-tests-from-scratch
@@ -226,7 +226,8 @@ fi
 # Download Scala if SCALA_HOME is not specified.
 ####################################################################
 if [ "x$SCALA_HOME" == "x" ] ; then
-  wget -nc $SCALA_DOWNLOAD_PATH
+  rm -rf ./scala*tgz
+  wget $SCALA_DOWNLOAD_PATH
   tar xvfz scala*tgz
   export SCALA_HOME="$WORKSPACE/scala-$SCALA_VERSION"
 fi


### PR DESCRIPTION
I noticed the test in jenkins has re-downloaded this 49 times now... https://amplab.cs.berkeley.edu/jenkins/job/Shark-Master-Hadoop1/ws/run-tests-from-scratch-workspace/
