### PR TITLE
Fix SerializationSuite failures due to SharkContext NPE

### DIFF
--- a/bin/ext/sharkserver.sh
+++ b/bin/ext/sharkserver.sh
@@ -18,10 +18,6 @@
 THISSERVICE=sharkserver
 export SERVICE_LIST="${SERVICE_LIST}${THISSERVICE} "
 
-# Use Java to launch Shark otherwise the unit tests cannot properly kill
-# the server process.
-export SHARK_LAUNCH_WITH_JAVA=1
-
 sharkserver() {
   echo "Starting the Shark Server"
   exec $FWDIR/run shark.SharkServer "$@"

--- a/run
+++ b/run
@@ -138,22 +138,16 @@ export JAVA_OPTS
 export ANT_OPTS=$JAVA_OPTS
 
 if [ "x$RUNNER" == "x" ] ; then
-  if [ "$SHARK_LAUNCH_WITH_JAVA" == "1" ]; then
-    CLASSPATH+=":$SCALA_HOME/lib/scala-library.jar"
-    CLASSPATH+=":$SCALA_HOME/lib/scala-compiler.jar"
-    CLASSPATH+=":$SCALA_HOME/lib/jline.jar"
-    if [ -n "$JAVA_HOME" ]; then
-      RUNNER="${JAVA_HOME}/bin/java"
-    else
-      RUNNER=java
-    fi
-    # The JVM doesn't read JAVA_OPTS by default so we need to pass it in
-    EXTRA_ARGS="$JAVA_OPTS"
+  CLASSPATH+=":$SCALA_HOME/lib/scala-library.jar"
+  CLASSPATH+=":$SCALA_HOME/lib/scala-compiler.jar"
+  CLASSPATH+=":$SCALA_HOME/lib/jline.jar"
+  if [ -n "$JAVA_HOME" ]; then
+    RUNNER="${JAVA_HOME}/bin/java"
   else
-    SCALA=${SCALA_HOME}/bin/scala
-    RUNNER="$SCALA -cp \"$CLASSPATH\""
-    EXTRA_ARGS=""
+    RUNNER=java
   fi
+  # The JVM doesn't read JAVA_OPTS by default so we need to pass it in
+  EXTRA_ARGS="$JAVA_OPTS"
 fi
 
 exec $RUNNER $EXTRA_ARGS "$@"

--- a/src/main/scala/shark/SharkContext.scala
+++ b/src/main/scala/shark/SharkContext.scala
@@ -358,5 +358,3 @@ object SharkContext {
   // A dummy init to make sure the object is properly initialized.
   def init() {}
 }
-
-

--- a/src/main/scala/shark/execution/serialization/KryoSerializer.scala
+++ b/src/main/scala/shark/execution/serialization/KryoSerializer.scala
@@ -19,9 +19,10 @@ package shark.execution.serialization
 
 import java.nio.ByteBuffer
 
-import org.apache.spark.SparkEnv
+import org.apache.spark.SparkConf
 import org.apache.spark.serializer.{KryoSerializer => SparkKryoSerializer}
 
+import shark.SharkContext
 
 /**
  * Java object serialization using Kryo. This is much more efficient, but Kryo
@@ -30,7 +31,15 @@ import org.apache.spark.serializer.{KryoSerializer => SparkKryoSerializer}
  */
 object KryoSerializer {
 
-  @transient val ser = new SparkKryoSerializer(SparkEnv.get.conf)
+  @transient var ser: SparkKryoSerializer = _
+
+  def initWithSharkContext(sc: SharkContext) {
+  	ser = new SparkKryoSerializer(sc.sparkEnv.conf)
+  }
+
+  def initWithSparkConf(sparkConf: SparkConf) {
+  	ser = new SparkKryoSerializer(sparkConf)
+  }
 
   def serialize[T](o: T): Array[Byte] = {
     ser.newInstance().serialize(o).array()

--- a/src/test/scala/shark/execution/serialization/SerializationSuite.scala
+++ b/src/test/scala/shark/execution/serialization/SerializationSuite.scala
@@ -46,13 +46,16 @@ object SerializationSuite {
 
 class SerializationSuite extends FunSuite {
 
+  // Initialize the Shark KryoSerializer singleton.
+  KryoSerializer.initWithSparkConf(new SparkConf(loadDefaults = false))
+
   test("Java serializing object inspectors") {
 
     val oi = PrimitiveObjectInspectorFactory.javaStringObjectInspector
     val ois = KryoSerializationWrapper(new ArrayBuffer[ObjectInspector])
     ois.value += oi
 
-    val ser = new SparkJavaSerializer(new SparkConf(false))
+    val ser = new SparkJavaSerializer(new SparkConf(loadDefaults = false))
     val bytes = ser.newInstance().serialize(ois)
     val desered = ser.newInstance()
       .deserialize[KryoSerializationWrapper[ArrayBuffer[ObjectInspector]]](bytes)
@@ -68,7 +71,7 @@ class SerializationSuite extends FunSuite {
     operator.localHiveOp = new org.apache.hadoop.hive.ql.exec.FileSinkOperator
     val opWrapped = OperatorSerializationWrapper(operator)
 
-    val ser = new SparkJavaSerializer(new SparkConf(false))
+    val ser = new SparkJavaSerializer(new SparkConf(loadDefaults = false))
     val bytes = ser.newInstance().serialize(opWrapped)
     val desered = ser.newInstance()
       .deserialize[OperatorSerializationWrapper[SharkFileSinkOperator]](bytes)


### PR DESCRIPTION
Changes:
- SharkEnv always contains a reference to SharkContext type (as opposed to SparkContext)
- Added initialize() methods to Shark's KryoSerializer singleton, to make it easier to pass SparkConf references needed for SparkKryoSerializer
- Always launch with Java for `bin/shark-shell`, due to scala-2.10's `scala` command loading a conflicting version of Akka.
