### PR TITLE
fix KryoSerializer NPE.

### DIFF
--- a/src/main/scala/shark/execution/serialization/KryoSerializer.scala
+++ b/src/main/scala/shark/execution/serialization/KryoSerializer.scala
@@ -19,7 +19,7 @@ package shark.execution.serialization
 
 import java.nio.ByteBuffer
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkEnv, SparkConf}
 import org.apache.spark.serializer.{KryoSerializer => SparkKryoSerializer}
 
 import shark.SharkContext
@@ -31,7 +31,7 @@ import shark.SharkContext
  */
 object KryoSerializer {
 
-  @transient var ser: SparkKryoSerializer = _
+  @transient var ser = new SparkKryoSerializer(SparkEnv.get.conf)
 
   def initWithSharkContext(sc: SharkContext) {
   	ser = new SparkKryoSerializer(sc.sparkEnv.conf)

--- a/src/main/scala/shark/execution/serialization/KryoSerializer.scala
+++ b/src/main/scala/shark/execution/serialization/KryoSerializer.scala
@@ -31,7 +31,7 @@ import shark.SharkContext
  */
 object KryoSerializer {
 
-  @transient var ser = new SparkKryoSerializer(SparkEnv.get.conf)
+  @transient var ser = new SparkKryoSerializer(new SparkConf())
 
   def initWithSharkContext(sc: SharkContext) {
   	ser = new SparkKryoSerializer(sc.sparkEnv.conf)


### PR DESCRIPTION
pull request #234 introduce an KryoSerializer NPE due to ser is not initialized in spark task,

```
java.lang.NullPointerException
        at shark.execution.serialization.KryoSerializer$.deserialize(KryoSerializer.scala:49)
        at shark.execution.serialization.OperatorSerializationWrapper.value(OperatorSerializationWrapper.scala:50)
        at shark.execution.package$.opSerWrapper2op(package.scala:30)
        at shark.execution.Operator$$anonfun$executeProcessPartition$1.apply(Operator.scala:336)
        at shark.execution.Operator$$anonfun$executeProcessPartition$1.apply(Operator.scala:335)
        at org.apache.spark.rdd.RDD$$anonfun$2.apply(RDD.scala:460)
        at org.apache.spark.rdd.RDD$$anonfun$2.apply(RDD.scala:460)
        at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:34)
        at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:241)
        at org.apache.spark.rdd.RDD.iterator(RDD.scala:232)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:109)
        at org.apache.spark.scheduler.Task.run(Task.scala:53)
        at org.apache.spark.executor.Executor$TaskRunner$$anonfun$run$1.apply$mcV$sp(Executor.scala:213)
        at org.apache.spark.deploy.SparkHadoopUtil.runAsUser(SparkHadoopUtil.scala:50)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:178)
        at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
        at java.lang.Thread.run(Thread.java:662)
```
