### PR TITLE
Accept spaces before (UN)CACHE, more helpful error message.

### DIFF
--- a/src/main/scala/shark/SharkDriver.scala
+++ b/src/main/scala/shark/SharkDriver.scala
@@ -183,7 +183,7 @@ private[shark] class SharkDriver(conf: HiveConf) extends Driver(conf) with LogHe
 
     try {
       val command = {
-        val varSubbedCmd = new VariableSubstitution().substitute(conf, cmd)
+        val varSubbedCmd = new VariableSubstitution().substitute(conf, cmd).trim
         val cmdInUpperCase = varSubbedCmd.toUpperCase
         if (cmdInUpperCase.startsWith("CACHE")) {
           QueryRewriteUtils.cacheToAlterTable(varSubbedCmd)

--- a/src/main/scala/shark/util/QueryRewriteUtils.scala
+++ b/src/main/scala/shark/util/QueryRewriteUtils.scala
@@ -30,7 +30,8 @@ object QueryRewriteUtils {
       val tableName = cmdSplit(1)
       "ALTER TABLE %s SET TBLPROPERTIES ('shark.cache' = 'true')".format(tableName)
     } else {
-      throw new SemanticException("CACHE accepts a single table name: 'CACHE <table name>'")
+      throw new SemanticException(
+        s"CACHE accepts a single table name: 'CACHE <table name>' (received command: '$cmd')")
     }
   }
 
@@ -40,7 +41,8 @@ object QueryRewriteUtils {
       val tableName = cmdSplit(1)
       "ALTER TABLE %s SET TBLPROPERTIES ('shark.cache' = 'false')".format(tableName)
     } else {
-      throw new SemanticException("UNCACHE accepts a single table name: 'UNCACHE <table name>'")
+      throw new SemanticException(
+        s"UNCACHE accepts a single table name: 'UNCACHE <table name>' (received command: '$cmd')")
     }  
   }
 }


### PR DESCRIPTION
This is most helpful when running a series of statements
using -e, when adding spaces increases readability.
