### PR TITLE
Fix for shark environment template when JAVA_OPTS is set.

### DIFF
--- a/conf/shark-env.sh.template
+++ b/conf/shark-env.sh.template
@@ -49,7 +49,7 @@ export HIVE_HOME=""
 
 # Java options
 # On EC2, change the local.dir to /mnt/tmp
-SPARK_JAVA_OPTS="-Dspark.local.dir=/tmp "
+SPARK_JAVA_OPTS=" -Dspark.local.dir=/tmp "
 SPARK_JAVA_OPTS+="-Dspark.kryoserializer.buffer.mb=10 "
 SPARK_JAVA_OPTS+="-verbose:gc -XX:-PrintGCDetails -XX:+PrintGCTimeStamps "
 export SPARK_JAVA_OPTS


### PR DESCRIPTION
The value of $SPARK_OPTS is concatenated directly onto the end of JAVA_OPTS in the run script.
(line 152)

Without a space in the shark-env.sh, this results in a parsing problem with existing JAVA_OPTS.

e.g. 
bone@zen:~/tools/shark-0.8.0-bin-cdh4/shark-0.8.0-> grep JAVA_OPTS ~/.bash_profile
export JAVA_OPTS="-Xmx3096m"

results in:
Starting the Shark Command Line Client
Invalid maximum heap size: -Xmx3096m-Dspark.local.dir=/tmp
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
