### PR TITLE
AstRewrite for count distinct can cause unexpected issues with certain queries

### DIFF
--- a/src/main/scala/shark/parse/ASTRewriteUtil.scala
+++ b/src/main/scala/shark/parse/ASTRewriteUtil.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConversions._
 
 import org.apache.hadoop.hive.ql.lib.Node
 import org.apache.hadoop.hive.ql.parse.{ASTNode, HiveParser}
+import org.apache.hadoop.util.StringUtils
 
 import shark.LogHelper
 import shark.parse.ASTNodeFactory._
@@ -134,9 +135,15 @@ object ASTRewriteUtil extends LogHelper {
   def countDistinctToGroupBy(rootAstNode: ASTNode): ASTNode = {
     // Find all TOK_QUERY nodes and transform any count-distincts subtree into a one with a
     // distinct/hash partition.
-    val queryNodes = findQueryNodes(rootAstNode)
-    for ((queryNode, queryId) <- queryNodes.zipWithIndex) {
-      countDistinctQueryToGroupBy(queryNode, queryId)
+    try {
+      val queryNodes = findQueryNodes(rootAstNode)
+      for ((queryNode, queryId) <- queryNodes.zipWithIndex) {
+        countDistinctQueryToGroupBy(queryNode, queryId)
+      }
+    } catch {
+      case e: Exception => {
+        logError("Attempt to rewrite query failed.\n" + StringUtils.stringifyException(e))
+      } 
     }
     rootAstNode
   }


### PR DESCRIPTION
Fix is to continue without rewrite under any issues in rewriting. Rewrite only when we can.

The exception below is seen for a single alter table add partition command with multiple partitions.

java.lang.ClassCastException: org.antlr.runtime.tree.CommonTree cannot be cast to org.apache.hadoop.hive.ql.lib.Node
at org.apache.hadoop.hive.ql.parse.ASTNode.getChildren(ASTNode.java:61)
at shark.parse.ASTRewriteUtil$.getChildren(ASTRewriteUtil.scala:57)
at shark.parse.ASTRewriteUtil$.findQueryNodes(ASTRewriteUtil.scala:120)
at shark.parse.ASTRewriteUtil$.countDistinctToGroupBy(ASTRewriteUtil.scala:137)
at shark.SharkDriver.compile(SharkDriver.scala:205)
....
