### PR TITLE
Ignore Hive JoinReorder optimizer for now.

### DIFF
--- a/src/main/scala/shark/SharkOptimizer.scala
+++ b/src/main/scala/shark/SharkOptimizer.scala
@@ -19,6 +19,7 @@ package shark
 
 import java.util.{List => JavaList}
 
+import org.apache.hadoop.hive.ql.optimizer.JoinReorder
 import org.apache.hadoop.hive.ql.optimizer.{Optimizer => HiveOptimizer, 
   SimpleFetchOptimizer, Transform}
 import org.apache.hadoop.hive.ql.parse.{ParseContext}
@@ -29,7 +30,7 @@ class SharkOptimizer extends HiveOptimizer with LogHelper {
    * Override Hive optimizer to skip SimpleFetchOptimizer, which is designed 
    * to let Hive avoid launching MR jobs on simple queries, but rewrites the 
    * query plan in a way that is inconvenient for Shark (replaces the FS operator 
-   *with a non-terminal ListSink operator).
+   * with a non-terminal ListSink operator).
    */
   override def optimize(): ParseContext  = {
 
@@ -46,7 +47,8 @@ class SharkOptimizer extends HiveOptimizer with LogHelper {
     while (it.hasNext()) {
       val transformation = it.next()
       transformation match {
-        case _:SimpleFetchOptimizer => {}
+        case _: SimpleFetchOptimizer => {}
+        case _: JoinReorder => {}
         case _ => {
           pctx = transformation.transform(pctx)
         }


### PR DESCRIPTION
Not sure how effective it is, since we don't track Hive's version of stats.
