### PR TITLE
Fixed path to the hadoop-test-0.20.2.jar

### DIFF
--- a/bin/dev/test
+++ b/bin/dev/test
@@ -57,7 +57,7 @@ fi
 
 
 SPARK_CLASSPATH+=":${HIVE_DEV_HOME}/build/ql/test/classes"
-SPARK_CLASSPATH+=":${HIVE_DEV_HOME}/build/ivy/lib/test/hadoop-test-0.20.2.jar"
+SPARK_CLASSPATH+=":${HIVE_DEV_HOME}/build/ivy/lib/hadoop0.20.shim/hadoop-test-0.20.2.jar"
 SPARK_CLASSPATH+=":${HIVE_DEV_HOME}/data/conf"
 export SPARK_CLASSPATH
 

--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -109,7 +109,7 @@ object SharkBuild extends Build {
 
     unmanagedJars in Test ++= Seq(
       file(System.getenv("HIVE_DEV_HOME")) / "build" / "ql" / "test" / "classes",
-      file(System.getenv("HIVE_DEV_HOME")) / "build/ivy/lib/test/hadoop-test-0.20.2.jar"
+      file(System.getenv("HIVE_DEV_HOME")) / "build/ivy/lib/hadoop0.20.shim/hadoop-test-0.20.2.jar"
     ),
 
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Updated path of the hadoop-test-0.20.2.jar in the bin/dev/test and SharkBuild.scala
