### PR TITLE
Removed hadoop-test-0.20.2.jar from the bin/dev/test

### DIFF
--- a/bin/dev/test
+++ b/bin/dev/test
@@ -57,7 +57,6 @@ fi
 
 
 SPARK_CLASSPATH+=":${HIVE_DEV_HOME}/build/ql/test/classes"
-SPARK_CLASSPATH+=":${HIVE_DEV_HOME}/build/ivy/lib/test/hadoop-test-0.20.2.jar"
 SPARK_CLASSPATH+=":${HIVE_DEV_HOME}/data/conf"
 export SPARK_CLASSPATH
 


### PR DESCRIPTION
as described - removed obsolete hadoop-test-0.20.2.jar from the bin/dev/test
