### PR TITLE
Compression fixes

### DIFF
--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -136,7 +136,7 @@ trait CompressedColumnBuilder[T] extends ColumnBuilder[T] with LogHelper {
       }
 
     logInfo("Compression scheme chosen for [%s] is %s with ratio %f".format(
-      columnName, scheme.compressionType, scheme.compressionRatio))
+      columnName, scheme.compressionType.getClass.getSimpleName, scheme.compressionRatio))
 
     scheme.compress(b, t)
   }

--- a/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
+++ b/src/main/scala/shark/memstore2/column/ColumnBuilder.scala
@@ -96,19 +96,30 @@ class DefaultColumnBuilder[T](val stats: ColumnStats[T], val t: ColumnType[T, _]
 
 trait CompressedColumnBuilder[T] extends ColumnBuilder[T] with LogHelper {
 
-  var compressionSchemes: Seq[CompressionAlgorithm] = Seq()
-  // Can be set in tests to ensure chosen compression
-  var scheme: CompressionAlgorithm = new NoCompression
+  private var compressionSchemes = Array.empty[CompressionAlgorithm]
 
+  /**
+   * Set the compression schemes to be used for this column. Only schemes that support
+   * the column's data type will be kept in the list.
+   */
+  def setCompressionSchemes(schemes: CompressionAlgorithm*) {
+    compressionSchemes = schemes.filter(_.supportsType(t)).toArray
+  }
+
+  /**
+   * Determines whether a particular compression algorithm should apply given the compression
+   * ratio. Test code can override this to force specific compression even if the compression
+   * ratio is not ideal.
+   */
   def shouldApply(scheme: CompressionAlgorithm): Boolean = {
     scheme.compressionRatio < 0.8
   }
 
-  override protected def gatherStats(v: T) = {
-    compressionSchemes.foreach { scheme =>
-      if (scheme.supportsType(t)) {
-        scheme.gatherStatsForCompressibility(v, t)
-      }
+  override protected def gatherStats(v: T) {
+    var i = 0
+    while (i < compressionSchemes.length) {
+      compressionSchemes(i).gatherStatsForCompressibility(v, t)
+      i += 1
     }
     super.gatherStats(v)
   }
@@ -116,27 +127,18 @@ trait CompressedColumnBuilder[T] extends ColumnBuilder[T] with LogHelper {
   override def build() = {
     val b = super.build()
 
-    import shark.memstore2.column.Implicits._
-
-    if (compressionSchemes.isEmpty) {
-      val strType: String = scheme.compressionType
-      logInfo(s"Compression scheme chosen for [$columnName] is $strType - no compression")
-      new NoCompression().compress(b, t)
-    } else {
-      val candidateScheme = scheme.compressionType match {
-        case DefaultCompressionType => compressionSchemes.minBy(_.compressionRatio)
-        case _ => scheme
-      }
-
-      val strType: String = candidateScheme.compressionType
-      logInfo(s"Compression scheme chosen for [$columnName] is $strType with ratio " +
-        candidateScheme.compressionRatio)
-      if (shouldApply(candidateScheme)) {
-        candidateScheme.compress(b, t)
+    val scheme: CompressionAlgorithm =
+      if (compressionSchemes.length == 0) {
+        new NoCompression
       } else {
-        new NoCompression().compress(b, t)
+        val scheme = compressionSchemes.minBy(_.compressionRatio)
+        if (shouldApply(scheme)) scheme else new NoCompression
       }
-    }
+
+    logInfo("Compression scheme chosen for [%s] is %s with ratio %f".format(
+      columnName, scheme.compressionType, scheme.compressionRatio))
+
+    scheme.compress(b, t)
   }
 }
 
@@ -168,7 +170,7 @@ object ColumnBuilder {
       case _ => new GenericColumnBuilder(columnOi)
     }
     if (shouldCompress) {
-      v.compressionSchemes = Seq(
+      v.setCompressionSchemes(
         new NoCompression,
         new RLE,
         new BooleanBitSetCompression,

--- a/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/ColumnIteratorSuite.scala
@@ -76,7 +76,7 @@ class ColumnIteratorSuite extends FunSuite {
     assert(builder.stats.max === true)
 
     builder = new BooleanColumnBuilder
-    builder.compressionSchemes = Seq(new RLE())
+    builder.setCompressionSchemes(new RLE)
     val a = Array.ofDim[java.lang.Boolean](100)
     Range(0,100).foreach { i =>
       a(i) = if (i < 10) true else if (i <80) false else null
@@ -113,7 +113,7 @@ class ColumnIteratorSuite extends FunSuite {
     assert(builder.stats.max === 15.toByte)
 
     builder = new ByteColumnBuilder
-    builder.compressionSchemes = Seq(new RLE())
+    builder.setCompressionSchemes(new RLE)
     testColumn(
       Array[java.lang.Byte](null, 2.toByte, 2.toByte, null, 4.toByte, 4.toByte,4.toByte,5.toByte),
       builder,
@@ -177,7 +177,7 @@ class ColumnIteratorSuite extends FunSuite {
     assert(builder.stats.max === 134)
 
     builder = new IntColumnBuilder
-    builder.compressionSchemes = Seq(new RLE())
+    builder.setCompressionSchemes(new RLE)
     val a = Array.ofDim[java.lang.Integer](100)
     Range(0,100).foreach { i =>
       a(i) = if (i < 10) 10 else if (i <80) 11 else null
@@ -214,7 +214,7 @@ class ColumnIteratorSuite extends FunSuite {
     assert(builder.stats.max === 15L)
 
     builder = new LongColumnBuilder
-    builder.compressionSchemes = Seq(new RLE())
+    builder.setCompressionSchemes(new RLE)
     val a = Array.ofDim[java.lang.Long](100)
     Range(0,100).foreach { i =>
       a(i) = if (i < 10) 10 else if (i <80) 11 else null
@@ -300,7 +300,7 @@ class ColumnIteratorSuite extends FunSuite {
     assert(builder.stats.max.toString === "b")
 
     builder = new StringColumnBuilder
-    builder.compressionSchemes = Seq(new RLE())
+    builder.setCompressionSchemes(new RLE)
     testColumn(
       Array[Text](new Text("a"), new Text("a"), null, new Text("b"), new Text("b"), new Text("Abcdz")),
       builder,

--- a/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressionAlgorithmSuite.scala
@@ -36,11 +36,11 @@ class CompressionAlgorithmSuite extends FunSuite {
 
     class TestColumnBuilder(val stats: ColumnStats[Int], val t: ColumnType[Int,_])
       extends CompressedColumnBuilder[Int] {
-      compressionSchemes = Seq(new RLE())
       override def shouldApply(scheme: CompressionAlgorithm) = true
     }
 
     val b = new TestColumnBuilder(new NoOpStats, INT)
+    b.setCompressionSchemes(new RLE)
     b.initialize(100)
     val oi = PrimitiveObjectInspectorFactory.javaIntObjectInspector
     b.append(123.asInstanceOf[Object], oi)


### PR DESCRIPTION
1. Fixed a bug that delta encoding was used for every column regardless of compression ratio.
2. Slightly improved performance of compression code. The AMPLab big data benchmark uservisits table used to take 3.5 mins on 5 nodes (20GB/node). With this tiny fix it takes slightly less than 3 mins.
