### PR TITLE
Null mergeCombiners will cause NPE in ExternalAppendOnlyMap

### DIFF
--- a/src/main/scala/shark/execution/CoGroupedRDD.scala
+++ b/src/main/scala/shark/execution/CoGroupedRDD.scala
@@ -65,7 +65,7 @@ class CoGroupAggregator
   extends Aggregator[Any, Any, ArrayBuffer[Any]](
     { x => ArrayBuffer(x) },
     { (b, x) => b += x },
-    null)
+    {(c1, c2) => c1++c2 })
   with Serializable
 
 // Disable map-side combine during aggregation.

--- a/src/main/scala/shark/execution/GroupByPostShuffleOperator.scala
+++ b/src/main/scala/shark/execution/GroupByPostShuffleOperator.scala
@@ -494,5 +494,5 @@ class GroupByPostShuffleOperator extends GroupByPreShuffleOperator
 object GroupByAggregator {
   def createCombiner(v: Any) = ArrayBuffer(v)
   def mergeValue(buf: ArrayBuffer[Any], v: Any) = buf += v
-  def mergeCombiners(c1: ArrayBuffer[V], c2: ArrayBuffer[V]) = c1 ++ c2
+  def mergeCombiners(c1: ArrayBuffer[Any], c2: ArrayBuffer[Any]) = c1 ++ c2
 }

--- a/src/main/scala/shark/execution/GroupByPostShuffleOperator.scala
+++ b/src/main/scala/shark/execution/GroupByPostShuffleOperator.scala
@@ -220,7 +220,7 @@ class GroupByPostShuffleOperator extends GroupByPreShuffleOperator
     } else {
       // No distinct keys.
       val aggregator = new Aggregator[Any, Any, ArrayBuffer[Any]](
-        GroupByAggregator.createCombiner _, GroupByAggregator.mergeValue _, null)
+        GroupByAggregator.createCombiner _, GroupByAggregator.mergeValue _, GroupByAggregator.mergeCombiners _)
       val hashedRdd = repartitionedRDD.mapPartitionsWithContext(
         (context, iter) => aggregator.combineValuesByKey(iter, context),
         preservesPartitioning = true)
@@ -494,4 +494,5 @@ class GroupByPostShuffleOperator extends GroupByPreShuffleOperator
 object GroupByAggregator {
   def createCombiner(v: Any) = ArrayBuffer(v)
   def mergeValue(buf: ArrayBuffer[Any], v: Any) = buf += v
+  def mergeCombiners(c1: ArrayBuffer[V], c2: ArrayBuffer[V]) = c1 ++ c2
 }


### PR DESCRIPTION
in most time , null mergeCombiners works fine if each key is different
from others, but if some key are duplicate , it will cause NPE when the
function mergeIfKeyExists is called in ExternalAppendOnlyMap.scala
