### PR TITLE
Only set the job description instead of also overriding the job group.

### DIFF
--- a/src/main/scala/shark/execution/SparkLoadTask.scala
+++ b/src/main/scala/shark/execution/SparkLoadTask.scala
@@ -153,9 +153,9 @@ class SparkLoadTask extends HiveTask[SparkLoadWork] with Serializable with LogHe
     val databaseName = work.databaseName
     val tableName = work.tableName
     // Set Spark's job description to be this query.
-    SharkEnv.sc.setJobGroup(
-      "shark.job",
+    SharkEnv.sc.setJobDescription(
       s"Updating table $databaseName.$tableName for a(n) ${work.commandType}")
+
     val hiveTable = Hive.get(conf).getTable(databaseName, tableName)
     // Use HadoopTableReader to help with table scans. The `conf` passed is reused across HadoopRDD
     // instantiations. 

--- a/src/main/scala/shark/execution/SparkTask.scala
+++ b/src/main/scala/shark/execution/SparkTask.scala
@@ -89,7 +89,7 @@ class SparkTask extends HiveTask[SparkWork] with Serializable with LogHelper {
     terminalOp.initializeMasterOnAll()
 
     // Set Spark's job description to be this query.
-    SharkEnv.sc.setJobGroup("shark.job", work.pctx.getContext.getCmd)
+    SharkEnv.sc.setJobDescription(work.pctx.getContext.getCmd)
 
     // Set the fair scheduler's pool using mapred.fairscheduler.pool if it is defined.
     Option(conf.get("mapred.fairscheduler.pool")).foreach { pool =>


### PR DESCRIPTION
This rolls back a change that I made during the port to 2.10 to avoid using a deprecated Spark API.  However, it looks like that API is going to be un-deprecated and that overriding the job group can break other systems.
