### PR TITLE
Allow users to control the number of tasks for table scan operations

### DIFF
--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -54,6 +54,9 @@ object SharkConfVars {
   // If true, then query plans are compressed before being sent
   val COMPRESS_QUERY_PLAN = new ConfVar("shark.queryPlan.compress", true)
 
+  // Number of mappers to force for table scan jobs
+  val NUM_MAPPERS = new ConfVar("shark.map.tasks", -1)
+  
   // Add Shark configuration variables and their default values to the given conf,
   // so default values show up in 'set'.
   def initializeWithDefaults(conf: Configuration) {

--- a/src/main/scala/shark/execution/TableScanOperator.scala
+++ b/src/main/scala/shark/execution/TableScanOperator.scala
@@ -120,6 +120,19 @@ class TableScanOperator extends TopOperator[TableScanDesc] {
   }
 
   override def execute(): RDD[_] = {
+
+    val numMappers = SharkConfVars.getIntVar(localHConf, SharkConfVars.NUM_MAPPERS)
+
+    // Try the use of given number of mappers for a job
+    if (numMappers > 0) {
+      logInfo("Setting the number of mappers to " + numMappers)
+      getBaseRDD.coalesce(numMappers, false)
+    } else {
+      getBaseRDD
+    }
+  }
+  
+  def getBaseRDD(): RDD[_] = {
     assert(parentOperators.size == 0)
 
     val tableNameSplit = tableDesc.getTableName.split('.') // Split from 'databaseName.tableName'


### PR DESCRIPTION
This will enable user's queries to perform well even for high cardinality partitioned tables.

set shark.map.tasks=100;
