### PR TITLE
fix "get scala version error"  ---  issue #Shark-219#

### DIFF
--- a/bin/dev/run-tests-from-scratch
+++ b/bin/dev/run-tests-from-scratch
@@ -203,7 +203,7 @@ export HIVE_HOME="$HIVE_DEV_HOME/build/dist"
 
 if [ "x$SCALA_HOME" != "x" ] ; then
   # User already specified SCALA_HOME. Make sure the correct version of Scala installed.
-  SCALA_HOME_VERSION=`${SCALA_HOME}/bin/scala -version|awk '{print $5}'`
+  SCALA_HOME_VERSION=`${SCALA_HOME}/bin/scala -version 2>&1|awk '{print $5}'`
   if [ "$SCALA_HOME_VERSION" != "$SCALA_VERSION" ] ; then
     echo "Your SCALA_HOME is version ${SCALA_HOME_VERSION}, but ${SCALA_VERSION} is required."
     exit -1


### PR DESCRIPTION
${SCALA_HOME}/bin/scala -version | awk '{print $5}' will tell us that the version is "Scala code runner version 2.10.3 -- Copyright 2002-2013, LAMP/EPFL"  rather than "2.10.3"  . Consequently,  the condition "if [ "$SCALA_HOME_VERSION" != "$SCALA_VERSION" ] " will never be true.

issue:https://spark-project.atlassian.net/browse/SHARK-219
