### PR TITLE
Fixed mismatched ordering after multiple data load

### DIFF
--- a/src/main/scala/shark/memstore2/MemoryTable.scala
+++ b/src/main/scala/shark/memstore2/MemoryTable.scala
@@ -72,7 +72,7 @@ private[shark] class MemoryTable(
   	if (_rddValueOpt.isDefined) {
       val (prevRDD, prevStats) = (prevRDDAndStatsOpt.get._1, prevRDDAndStatsOpt.get._2)
       val updatedRDDValue = _rddValueOpt.get
-      updatedRDDValue.rdd = RDDUtils.unionAndFlatten(prevRDD, newRDD)
+      updatedRDDValue.rdd = RDDUtils.unionAndFlatten(newRDD, prevRDD)
       updatedRDDValue.stats = Table.mergeStats(newStats, prevStats).toMap
     } else {
       put(newRDD, newStats.toMap)


### PR DESCRIPTION
The TablePartition and TablePartitionStats are not inserted in the same order within the RDD when multiple data load is performed. This may cause problem in partition pruning. For detailed description of the problem, please refer to https://groups.google.com/forum/?fromgroups#!topic/shark-users/8VQZmRNCVQk
