### PR TITLE
Add a table property to indicate a table being cached

### DIFF
--- a/src/main/scala/shark/memstore2/SharkTblProperties.scala
+++ b/src/main/scala/shark/memstore2/SharkTblProperties.scala
@@ -39,6 +39,9 @@ object SharkTblProperties {
   // Default value for the "shark.cache" table property
   val CACHE_FLAG = new TableProperty("shark.cache", "true")
 
+  // Whether we are currently in the process of caching the table (meaning it cannot be accessed).
+  val CACHE_IN_PROGRESS_FLAG = new TableProperty("shark.cache.inProgress", "false")
+
   def getOrSetDefault(tblProps: JavaMap[String, String], variable: TableProperty): String = {
     if (!tblProps.containsKey(variable.varname)) {
       tblProps.put(variable.varname, variable.defaultVal)
@@ -54,6 +57,7 @@ object SharkTblProperties {
       tblProps: JavaMap[String, String],
       isPartitioned: Boolean = false): JavaMap[String, String] = {
     tblProps.put(CACHE_FLAG.varname, CACHE_FLAG.defaultVal)
+    tblProps.put(CACHE_IN_PROGRESS_FLAG.varname, CACHE_IN_PROGRESS_FLAG.defaultVal)
     if (isPartitioned) {
       tblProps.put(CACHE_POLICY.varname, CACHE_POLICY.defaultVal)
     }
@@ -62,6 +66,7 @@ object SharkTblProperties {
 
   def removeSharkProperties(tblProps: JavaMap[String, String]) {
     tblProps.remove(CACHE_FLAG.varname)
+    tblProps.remove(CACHE_IN_PROGRESS_FLAG.varname)
     tblProps.remove(CACHE_POLICY.varname)
     tblProps.remove(MAX_PARTITION_CACHE_SIZE.varname)
   }


### PR DESCRIPTION
While a table is in the process of being cached in memory or offheap, it is actually inaccessible, because we won't fall back to the base data. This patch puts a band-aid on that by allowing the user to check when the caching is complete, and to disallow multiple cache tasks to execute on the same table at the same time (where the behavior is not defined).
