### PR TITLE
Update SharkDriver.scala

### DIFF
--- a/src/main/scala/shark/SharkDriver.scala
+++ b/src/main/scala/shark/SharkDriver.scala
@@ -146,6 +146,24 @@ private[shark] class SharkDriver(conf: HiveConf) extends Driver(conf) with LogHe
     // Init Hive Driver.
     super.init()
   }
+  //overide the close() 
+    override def close(): Int = {
+   
+   try {
+    
+    super.close()
+    
+    }catch{
+     case e: Exception => {
+
+        //logDebug(errorMessage, "\n" + StringUtils.stringifyException(e))
+      
+      }
+    }finally {
+        //perfLogger.PerfLogEnd(LOG, PerfLogger.DO_AUTHORIZATION)
+    }
+    return 0
+  }
 
   def tableRdd(cmd: String): Option[TableRDD] = {
     useTableRddSink = true
@@ -165,6 +183,18 @@ private[shark] class SharkDriver(conf: HiveConf) extends Driver(conf) with LogHe
    * Overload compile to use Shark's semantic analyzers.
    */
   override def compile(cmd: String, resetTaskIds: Boolean): Int = {
+    
+      //The select privilege is not work when we set metastore pression,
+      //so we may run the super method by hive first to check whether pass the validation.
+   
+   val reCode= super.compile(cmd,resetTaskIds)
+    
+     if ( reCode != 0 ) {
+     	return reCode
+     
+    } 
+    
+    
     val perfLogger: PerfLogger = PerfLogger.getPerfLogger()
     perfLogger.PerfLogBegin(LOG, PerfLogger.COMPILE)
 


### PR DESCRIPTION
Scenario 1 :The select privilege is not working when we set metastore pression.
Scenario 2: The yarn user will be executed when Shark submit JOB and write the scratch doc, and it will try eliminating the utilized account. However, it will report waring exception due to 
 (Reloading the "close" to ensure ordinary operation) , That lead  Queries can't return the correct verification code.
