### PR TITLE
Bug fix: RLDecoder.hasNext may lose duplicated values

### DIFF
--- a/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
+++ b/src/main/scala/shark/memstore2/column/CompressedColumnIterator.scala
@@ -88,7 +88,7 @@ class RLDecoder[V](buffer: ByteBuffer, columnType: ColumnType[_, V]) extends Ite
   private var _count: Int = 0
   private val _current: V = columnType.newWritable()
 
-  override def hasNext = buffer.hasRemaining()
+  override def hasNext = _count < _run || buffer.hasRemaining()
 
   override def next(): V = {
     if (_count == _run) {

--- a/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
+++ b/src/test/scala/shark/memstore2/column/CompressedColumnIteratorSuite.scala
@@ -78,6 +78,7 @@ class CompressedColumnIteratorSuite extends FunSuite {
       }
 
       l.foreach { x =>
+        assert(iter.hasNext)
         iter.next()
         assert(t.get(iter.current, oi) === x)
       }


### PR DESCRIPTION
When the last several elements of some column are duplicated, `RLDecoder.hasNext` only returns `true` for the first one and loses all those duplicated values.
