### PR TITLE
unnecessary serialize/deserialize for cases where no conversion was performed

### DIFF
--- a/src/main/scala/shark/execution/HadoopTableReader.scala
+++ b/src/main/scala/shark/execution/HadoopTableReader.scala
@@ -196,11 +196,11 @@ class HadoopTableReader(@transient _tableDesc: TableDesc, @transient _localHConf
         val rowWithPartArr = new Array[Object](2)
         // Map each tuple to a row object
         
+        // this is done per partition, and no necessary put it in the iterations (in iter.map).
+        rowWithPartArr.update(1, partValues)
         if (partTblObjectInspectorConverter.isInstanceOf[IdentityConverter]) {
           iter.map { value =>
-            val deserializedRow = partSerDe.deserialize(value)
-            rowWithPartArr.update(0, deserializedRow)
-            rowWithPartArr.update(1, partValues)
+            rowWithPartArr.update(0, partSerDe.deserialize(value))
             rowWithPartArr.asInstanceOf[Object]
           }
         }
@@ -226,7 +226,6 @@ class HadoopTableReader(@transient _tableDesc: TableDesc, @transient _localHConf
               }
             }
             rowWithPartArr.update(0, deserializedRow)
-            rowWithPartArr.update(1, partValues)
             rowWithPartArr.asInstanceOf[Object]
           }
         }


### PR DESCRIPTION
If partition schema does not match table schema, the row (formed by deserializing through partition serde) is converted to match the table schema. If conversion was performed, convertedRow will be a standard Object, but if conversion wasn't necessary, it will still be lazy.

We can't have both (standard and lazy objects) across partitions, so we serialize and deserialize again to make it lazy.

This extra serialize/deserialize is being performed irrespective of the fact that whether conversion was done or not.

There are two effects of this serialization / deserialization:

1) Extra serialization / deserilization cost for cases, where no conversion happened.

2) If a table is created using ThriftDeserializer, the non-availability of serialize function in it makes it unusable in this context.

The fix done is that in case conversion was not done (when partition and table serde match), then this serialization and deserialization step should be skipped, since it is not required as the object would still be lazy. This shall also allow users to be able to use ThriftDeserializer in such a case. 
