### PR TITLE
Fix the rdd recovery of table from the non-default database

### DIFF
--- a/src/main/scala/shark/memstore2/TableRecovery.scala
+++ b/src/main/scala/shark/memstore2/TableRecovery.scala
@@ -58,6 +58,7 @@ object TableRecovery extends LogHelper {
           logInfo(logMessage)
         }
         val cmd = QueryRewriteUtils.cacheToAlterTable("CACHE %s".format(tableName))
+        cmdRunner(s"use $databaseName")
         cmdRunner(cmd)
       }
     }


### PR DESCRIPTION
Previously only support recovery RDD from the default database.

I was trying to change the code like
val cmd = QueryRewriteUtils.cacheToAlterTable("CACHE %s".format(s"$databaseName.$tableName"))

However, seems the Hive doesn't support altering table with database name prefixed.
e.g. "alter table db2.test1 set tblproperties("shark.cache"="memory"); will fail.
