### PR TITLE
FileAlreadyExistException when writing tachyon table

### DIFF
--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -56,7 +56,7 @@ object SharkBuild extends Build {
 
   // Whether to build Shark with Tachyon jar.
   val TACHYON_ENABLED = true
-  val TACHYON_VERSION = "0.4.1"
+  val TACHYON_VERSION = "0.5.0"
 
   lazy val root = Project(
     id = "root",

--- a/src/main/scala/shark/SharkConfVars.scala
+++ b/src/main/scala/shark/SharkConfVars.scala
@@ -57,6 +57,16 @@ object SharkConfVars {
   // Number of mappers to force for table scan jobs
   val NUM_MAPPERS = new ConfVar("shark.map.tasks", -1)
   
+  // WriteType for Tachyon off-heap table writer,e.g., "TRY_CACHE", "MUST_CACHE",
+  // "CACHE_THROUGH", "THROUGH".
+  // For the reliability concern, we strongly recommend to use the default "CACHE_THROUGH",
+  // which means to write the table synchronously to the under fs, and cache the host columns.
+  // Both "TRY_CACHE" and "MUST_CACHE" options only cache the table with better write
+  // performance. However be careful to use those two options! If the entire table
+  // cannot be fully cached, some data part will be evicted and lost forever.
+  // "THROUGH" only writes the table to under fs and with no cache at all.
+  val TACHYON_WRITER_WRITETYPE = new ConfVar("shark.tachyon.writetype", "CACHE_THROUGH")
+
   // Add Shark configuration variables and their default values to the given conf,
   // so default values show up in 'set'.
   def initializeWithDefaults(conf: Configuration) {

--- a/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
+++ b/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
@@ -206,7 +206,7 @@ object MemoryStoreSinkOperator {
   def processOffHeapSinkPartition(op: OperatorSerializationWrapper[MemoryStoreSinkOperator], 
       offHeapWriter: OffHeapTableWriter) = {
     def writeFiles(context: TaskContext, iter: Iterator[_]): Long = {
-      op.logDebug("Started executing mapPartitions for operator: " + op)
+      op.logDebug("Started executing writeFiles for operator: " + op)
       val partId = context.partitionId
       val partition = iter.next().asInstanceOf[TablePartition]
       val taskTmpDir = context.stageId + "_" + context.partitionId + "_" + context.attemptId
@@ -216,7 +216,7 @@ object MemoryStoreSinkOperator {
         writeBytes += buf.limit 
       }
       offHeapWriter.commitPartition(partId, taskTmpDir)
-      op.logDebug("Finished executing mapPartitions for operator: " + op)
+      op.logDebug("Finished executing writeFiles for operator: " + op)
       writeBytes
     }
     writeFiles _

--- a/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
+++ b/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
@@ -18,20 +18,18 @@
 package shark.execution
 
 import java.nio.ByteBuffer
-
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.BeanProperty
-
+import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.io.Writable
-
 import org.apache.spark.rdd.{RDD, UnionRDD}
 import org.apache.spark.storage.StorageLevel
-
 import shark.{SharkConfVars, SharkEnv}
 import shark.execution.serialization.{OperatorSerializationWrapper, JavaSerializer}
 import shark.memstore2._
-
 import org.apache.spark.TaskContext
+import org.apache.spark.SerializableWritable
+import org.apache.spark.broadcast.Broadcast
 /**
  * Cache the RDD and force evaluate it (so the cache is filled).
  */
@@ -129,8 +127,11 @@ class MemoryStoreSinkOperator extends TerminalOperator {
       // Put the table in off-heap storage.
       op.logInfo("Putting RDD for %s.%s in off-heap storage".format(databaseName, tableName))
       offHeapWriter.createTable()
+      val broadcastedHiveConf
+        = outputRDD.context.broadcast(new SerializableWritable(op.getLocalHconf))
       outputRDD.context.runJob(
-          outputRDD, MemoryStoreSinkOperator.processOffHeapSinkPartition(offHeapWriter))
+          outputRDD,
+          MemoryStoreSinkOperator.processOffHeapSinkPartition(offHeapWriter, broadcastedHiveConf))
       offHeapWriter.cleanTmpPath()
     } else {
       // Run a job on the RDD that contains the query output to force the data into the memory
@@ -203,13 +204,15 @@ class MemoryStoreSinkOperator extends TerminalOperator {
 }
 
 object MemoryStoreSinkOperator {
-  def processOffHeapSinkPartition(offHeapWriter: OffHeapTableWriter) = {
+  def processOffHeapSinkPartition(offHeapWriter: OffHeapTableWriter,
+    broadcastedHiveConf: Broadcast[SerializableWritable[HiveConf]]) = {
     def writeFiles(context: TaskContext, iter: Iterator[_]): Long = {
       val partId = context.partitionId
       val partition = iter.next().asInstanceOf[TablePartition]
       val taskTmpDir = context.stageId + "_" + context.partitionId + "_" + context.attemptId
       var writeBytes: Long = 0
       partition.toOffHeap.zipWithIndex.foreach { case(buf, column) =>
+        offHeapWriter.setLocalHconf(broadcastedHiveConf.value.value)
         offHeapWriter.writePartitionColumn(partId, column, buf, taskTmpDir)
         writeBytes += buf.limit 
       }

--- a/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
+++ b/src/main/scala/shark/execution/MemoryStoreSinkOperator.scala
@@ -18,18 +18,22 @@
 package shark.execution
 
 import java.nio.ByteBuffer
+
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.BeanProperty
+
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.io.Writable
-import org.apache.spark.rdd.{RDD, UnionRDD}
+
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.rdd.{RDD, UnionRDD}
+import org.apache.spark.{TaskContext, SerializableWritable}
+
 import shark.{SharkConfVars, SharkEnv}
 import shark.execution.serialization.{OperatorSerializationWrapper, JavaSerializer}
 import shark.memstore2._
-import org.apache.spark.TaskContext
-import org.apache.spark.SerializableWritable
-import org.apache.spark.broadcast.Broadcast
+
 /**
  * Cache the RDD and force evaluate it (so the cache is filled).
  */
@@ -78,7 +82,7 @@ class MemoryStoreSinkOperator extends TerminalOperator {
     localHconf.setInt(SharkConfVars.COLUMN_BUILDER_PARTITION_SIZE.varname, partitionSize)
     localHconf.setBoolean(SharkConfVars.COLUMNAR_COMPRESSION.varname, shouldCompress)
   }
-  
+
   override def execute(): RDD[_] = {
     val inputRdd = if (parentOperators.size == 1) executeParents().head._2 else null
 

--- a/src/main/scala/shark/execution/SparkLoadTask.scala
+++ b/src/main/scala/shark/execution/SparkLoadTask.scala
@@ -232,7 +232,8 @@ class SparkLoadTask extends HiveTask[SparkLoadWork] with Serializable with LogHe
       }
       offHeapWriter.createTable()
       transformedRdd.context.runJob(
-        transformedRdd, MemoryStoreSinkOperator.processOffHeapSinkPartition(offHeapWriter))
+        transformedRdd, MemoryStoreSinkOperator.processOffHeapSinkPartition(offHeapWriter,
+          broadcastedHiveConf))
     } else {
       transformedRdd.persist(StorageLevel.MEMORY_AND_DISK)
       transformedRdd.context.runJob(

--- a/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
+++ b/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
@@ -80,9 +80,9 @@ abstract class OffHeapTableWriter extends Serializable {
 
   /** Write the data of a partition of a given column. Called only on worker nodes. */ 
   def writePartitionColumn(part: Int, column: Int, data: ByteBuffer, tempDir: String)
-  
+
   def commitPartition(part: Int, numColumns: Int, tempDir: String)
-  
+
   def cleanTmpPath()
 }
 

--- a/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
+++ b/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
@@ -20,6 +20,9 @@ package shark.memstore2
 import java.util
 import java.nio.ByteBuffer
 
+import scala.reflect.BeanProperty
+
+import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.spark.rdd.RDD
 
 import shark.LogHelper
@@ -67,6 +70,7 @@ abstract class OffHeapStorageClient {
 }
 
 abstract class OffHeapTableWriter extends Serializable {
+  @transient @BeanProperty var localHconf: HiveConf = _
 
   /** Creates this table. Called only on the driver node. */
   def createTable()

--- a/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
+++ b/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
@@ -79,7 +79,7 @@ abstract class OffHeapTableWriter extends Serializable {
   
   def writePartitionColumn(part: Int, column: Int, data: ByteBuffer, tempDir: String)
   
-  def commitPartition(part: Int, tempDir: String)
+  def commitPartition(part: Int, numColumns: Int, tempDir: String)
   
   def cleanTmpPath()
 }

--- a/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
+++ b/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
@@ -74,9 +74,7 @@ abstract class OffHeapTableWriter extends Serializable {
   /** Sets stats on this table. Called only on the driver node. */
   def setStats(indexToStats: collection.Map[Int, TablePartitionStats])
 
-  /** Write the data of a partition of a given column. Called only on worker nodes. */
-  def writeColumnPartition(column: Int, part: Int, data: ByteBuffer)
-  
+  /** Write the data of a partition of a given column. Called only on worker nodes. */ 
   def writePartitionColumn(part: Int, column: Int, data: ByteBuffer, tempDir: String)
   
   def commitPartition(part: Int, numColumns: Int, tempDir: String)

--- a/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
+++ b/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
@@ -76,6 +76,12 @@ abstract class OffHeapTableWriter extends Serializable {
 
   /** Write the data of a partition of a given column. Called only on worker nodes. */
   def writeColumnPartition(column: Int, part: Int, data: ByteBuffer)
+  
+  def writePartitionColumn(part: Int, column: Int, data: ByteBuffer, tempDir: String)
+  
+  def commitPartition(part: Int, tempDir: String)
+
+  def cleanTmpPath()
 }
 
 /** Responsible for creating OffHeapStorageClients. Will be called on master and worker nodes. */

--- a/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
+++ b/src/main/scala/shark/memstore2/OffHeapStorageClient.scala
@@ -80,7 +80,7 @@ abstract class OffHeapTableWriter extends Serializable {
   def writePartitionColumn(part: Int, column: Int, data: ByteBuffer, tempDir: String)
   
   def commitPartition(part: Int, tempDir: String)
-
+  
   def cleanTmpPath()
 }
 

--- a/src/tachyon_enabled/scala/shark/tachyon/TachyonOffHeapTableWriter.scala
+++ b/src/tachyon_enabled/scala/shark/tachyon/TachyonOffHeapTableWriter.scala
@@ -48,15 +48,6 @@ class TachyonOffHeapTableWriter(@transient path: String, @transient numColumns: 
   // This is only used on worker nodes.
   @transient lazy val rawTable = tfs.getRawTable(rawTableId)
 
-  override def writeColumnPartition(column: Int, part: Int, data: ByteBuffer) {
-    val rawColumn = rawTable.getRawColumn(column)
-    rawColumn.createPartition(part)
-    val file = rawColumn.getPartition(part)
-    val outStream = file.getOutStream(WriteType.CACHE_THROUGH)
-    outStream.write(data.array(), 0, data.limit())
-    outStream.close()
-  }
-
   override def writePartitionColumn(part: Int, column: Int, data: ByteBuffer, tempDir: String) {
     val tmpPath = rawTable.getPath() + Constants.PATH_SEPARATOR + TEMP
     val fid = tfs.createFile(tmpPath + Constants.PATH_SEPARATOR + tempDir + Constants.PATH_SEPARATOR 

--- a/src/tachyon_enabled/scala/shark/tachyon/TachyonOffHeapTableWriter.scala
+++ b/src/tachyon_enabled/scala/shark/tachyon/TachyonOffHeapTableWriter.scala
@@ -67,12 +67,14 @@ class TachyonOffHeapTableWriter(@transient path: String, @transient numColumns: 
     outStream.close()
   }
   
-  override def commitPartition(part: Int, tempDir: String) {
+  override def commitPartition(part: Int, numColumns: Int, tempDir: String) {
     val tmpPath = rawTable.getPath() + Constants.PATH_SEPARATOR + TEMP
-    (0 until rawTable.getColumns()).reverse.foreach { column =>
-      tfs.rename(tmpPath + Constants.PATH_SEPARATOR + tempDir + Constants.PATH_SEPARATOR
-          + column + Constants.PATH_SEPARATOR + part, rawTable.getPath() + Constants.PATH_SEPARATOR 
-          + MasterInfo.COL + column + Constants.PATH_SEPARATOR + part)
+    (0 until numColumns).reverse.foreach { column =>
+      val srcPath = tmpPath + Constants.PATH_SEPARATOR + tempDir + Constants.PATH_SEPARATOR +
+          column + Constants.PATH_SEPARATOR + part
+      val destPath = rawTable.getPath() + Constants.PATH_SEPARATOR +
+          MasterInfo.COL + column + Constants.PATH_SEPARATOR + part
+      tfs.rename(srcPath, destPath)
     }
     tfs.delete(tmpPath + Constants.PATH_SEPARATOR + tempDir, true)
   }

--- a/src/tachyon_enabled/scala/shark/tachyon/TachyonOffHeapTableWriter.scala
+++ b/src/tachyon_enabled/scala/shark/tachyon/TachyonOffHeapTableWriter.scala
@@ -69,7 +69,7 @@ class TachyonOffHeapTableWriter(@transient path: String, @transient numColumns: 
   
   override def commitPartition(part: Int, tempDir: String) {
     val tmpPath = rawTable.getPath() + Constants.PATH_SEPARATOR + TEMP
-    (0 until rawTable.getColumns()).foreach { column =>
+    (0 until rawTable.getColumns()).reverse.foreach { column =>
       tfs.rename(tmpPath + Constants.PATH_SEPARATOR + tempDir + Constants.PATH_SEPARATOR
           + column + Constants.PATH_SEPARATOR + part, rawTable.getPath() + Constants.PATH_SEPARATOR 
           + MasterInfo.COL + column + Constants.PATH_SEPARATOR + part)


### PR DESCRIPTION
currently Shark write data into Tachyon table directly by RAWTable interface in Tachyon.
when  speculation execution is on,   it throws FileAlreadyExistException because two tasks attempts to write same partition into Tachyon table
the approach to solve the problem is first write output of each task into a temp folder,  then commit the result when the task ends. just like write to HDFS.
