### PR TITLE
Makes the JDBC server to work

### DIFF
--- a/bin/ext/sharkserver2.sh
+++ b/bin/ext/sharkserver2.sh
@@ -24,7 +24,7 @@ export SHARK_LAUNCH_WITH_JAVA=1
 
 sharkserver2() {
   echo "Starting the Shark Server"
-  exec $FWDIR/sbt/sbt "run-main shark.SharkServer2" "$@"
+  exec $FWDIR/run "shark.SharkServer2" "$@"
 }
 
 sharkserver2_help() {

--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -32,7 +32,7 @@ object SharkBuild extends Build {
 
   val SHARK_ORGANIZATION = "edu.berkeley.cs.shark"
 
-  val SPARK_VERSION = "1.1.0-SNAPSHOT"
+  val SPARK_VERSION = "1.0.1-SNAPSHOT"
 
   val SCALA_VERSION = "2.10.4"
 

--- a/project/SharkBuild.scala
+++ b/project/SharkBuild.scala
@@ -32,7 +32,7 @@ object SharkBuild extends Build {
 
   val SHARK_ORGANIZATION = "edu.berkeley.cs.shark"
 
-  val SPARK_VERSION = "1.0.0-SNAPSHOT"
+  val SPARK_VERSION = "1.1.0-SNAPSHOT"
 
   val SCALA_VERSION = "2.10.4"
 
@@ -77,7 +77,7 @@ object SharkBuild extends Build {
 
 
   /** Extra artifacts not included in Spark SQL's Hive support. */
-  val hiveArtifacts = Seq("hive-cli", "hive-jdbc")
+  val hiveArtifacts = Seq("hive-cli", "hive-jdbc", "hive-beeline")
   val hiveDependencies = hiveArtifacts.map ( artifactId =>
     "org.spark-project.hive" % artifactId % "0.12.0" excludeAll(
       excludeGuava, excludeLog4j, excludeAsm, excludeNetty, excludeXerces, excludeServlet)
@@ -114,7 +114,7 @@ object SharkBuild extends Build {
       "Cloudera Repository" at "https://repository.cloudera.com/artifactory/cloudera-repos/",
       "Local Maven" at Path.userHome.asFile.toURI.toURL + ".m2/repository"
     ),
- 
+
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT"))

--- a/run
+++ b/run
@@ -62,19 +62,6 @@ if [ -f "${HIVE_CONF_DIR}/hive-env.sh" ]; then
   . "${HIVE_CONF_DIR}/hive-env.sh"
 fi
 
-# Add Shark jars.
-for jar in `find $SHARK_HOME/lib -name '*jar'`; do
-  SPARK_CLASSPATH+=:$jar
-done
-for jar in `find $SHARK_HOME/lib_managed/jars -name '*jar'`; do
-  SPARK_CLASSPATH+=:$jar
-done
-for jar in `find $SHARK_HOME/lib_managed/bundles -name '*jar'`; do
-  SPARK_CLASSPATH+=:$jar
-done
-
-SPARK_CLASSPATH+=:$HIVE_CONF_DIR
-
 # Build up Shark's jar or classes.
 SHARK_CLASSES="$SHARK_HOME/target/scala-$SCALA_VERSION/classes"
 SHARK_JAR="$SHARK_HOME/target/scala-$SCALA_VERSION/shark_$SCALA_VERSION-$SHARK_VERSION.jar"
@@ -91,6 +78,19 @@ else
 fi
 
 SPARK_CLASSPATH+=":$SHARK_HOME/target/scala-$SCALA_VERSION/test-classes"
+
+# Add Shark jars.
+for jar in `find $SHARK_HOME/lib_managed/jars -name '*jar'`; do
+  SPARK_CLASSPATH+=:$jar
+done
+for jar in `find $SHARK_HOME/lib_managed/bundles -name '*jar'`; do
+  SPARK_CLASSPATH+=:$jar
+done
+for jar in `find $SHARK_HOME/lib_managed/orbits -name '*jar'`; do
+  SPARK_CLASSPATH+=:$jar
+done
+
+SPARK_CLASSPATH+=:$HIVE_CONF_DIR
 
 
 SHARK_JAR="$SHARK_HOME/target/scala-$SCALA_VERSION/shark_$SCALA_VERSION-$SHARK_VERSION.jar"

--- a/src/main/scala/shark/SharkServer2.scala
+++ b/src/main/scala/shark/SharkServer2.scala
@@ -1,19 +1,15 @@
 package shark
 
+import scala.collection.JavaConversions._
+
 import org.apache.commons.logging.LogFactory
-import org.apache.hadoop.hive.common.LogUtils
-import org.apache.hadoop.hive.common.LogUtils.LogInitializationException
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hive.service.cli.thrift.ThriftBinaryCLIService
 import org.apache.hive.service.server.{HiveServer2, ServerOptionsProcessor}
-import org.apache.hive.service.CompositeService
-import org.apache.spark.SparkEnv
-import shark.server.SharkCLIService
-
-import scala.collection.JavaConversions._
-
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.hive.HiveContext
+
+import shark.server.SharkCLIService
 
 /**
  * The main entry point for the Shark port of HiveServer2.  Starts up a HiveContext and a SharkServer2 thrift server.
@@ -70,5 +66,3 @@ private[shark] class SharkServer2(hiveContext: HiveContext) extends HiveServer2 
     sharkInit(hiveConf)
   }
 }
-
-

--- a/src/main/scala/shark/server/SharkOperationManager.scala
+++ b/src/main/scala/shark/server/SharkOperationManager.scala
@@ -104,12 +104,7 @@ class SharkOperationManager(hiveContext: HiveContext) extends OperationManager w
           logger.debug(result.queryExecution.toString())
           iter = result.queryExecution.toRdd.toLocalIterator
           dataTypes = result.queryExecution.analyzed.output.map(_.dataType).toArray
-
-          // Native Commands (such as DDL) run in Hive and do not return results.
-          if (!result.queryExecution.logical.isInstanceOf[NativeCommand])
-            setHasResultSet(true)
-          else
-            setHasResultSet(false)
+          setHasResultSet(true)
         } catch {
           // Actually do need to catch Throwable as some failures don't inherit from Exception and HiveServer will
           // silently swallow them.

--- a/src/test/scala/shark/SharkServer2Suite.scala
+++ b/src/test/scala/shark/SharkServer2Suite.scala
@@ -42,9 +42,6 @@ class SharkServer2Suite extends FunSuite with BeforeAndAfterAll with TestUtils w
     // hard to clean up Hive resources entirely, so we just start a new process and kill
     // that process for cleanup.
     val defaultArgs = Seq("./bin/shark", "--service", "sharkserver2",
-      "--verbose",
-      "-p",
-      PORT,
       "--hiveconf",
       "hive.root.logger=INFO,console",
       "--hiveconf",


### PR DESCRIPTION
Made some minor changes to make JDBC server to work:
1. `SharkServer2` should be started with the `run` script to leverage the computed `CLASSPATH` and detect user Hive and Hadoop configurations.
2. Hive native commands in Spark SQL now have output too, so always `setHasResultSet(true)`.
3. Updated dependencies: `hive-beeline` is added as a runtime dependency required by `bin/beeline`.

A sample session below. Starting `SharkServer2`:

```
$ ./bin/shark --service sharkserver2
...
14/06/18 19:41:29 INFO shark.SharkServer2$: SharkServer2 started
14/06/18 19:41:29 INFO thrift.ThriftCLIService: ThriftBinaryCLIService listening on localhost/127.0.0.1:10000
```

Connect to the JDBC server with BeeLine:

```
$ ./bin/beeline

Beeline version 0.12.0 by Apache Hive
beeline> !connect jdbc:hive2://localhost:10000
scan complete in 3ms
Connecting to jdbc:hive2://localhost:10000
Enter username for jdbc:hive2://localhost:10000: lian
Enter password for jdbc:hive2://localhost:10000: 
Connected to: Hive (version 0.12.0)
Driver: Hive (version 0.12.0)
Transaction isolation: TRANSACTION_REPEATABLE_READ
0: jdbc:hive2://localhost:10000> show tables;
+--------------+
|    result    |
+--------------+
| hive_table   |
| shark_table  |
+--------------+
2 rows selected (0.952 seconds)
0: jdbc:hive2://localhost:10000> explain select key, count(*) from shark_table group by key limit 10;
+-------------------------------------------------------------------------------------+
|                                        plan                                         |
+-------------------------------------------------------------------------------------+
| ExplainCommand [plan#44:0]                                                          |
|  Limit 10                                                                           |
|   Aggregate false, [key#37], [key#37,SUM(PartialCount#39L) AS c_1#35L]              |
|    Exchange (HashPartitioning [key#37:0], 200)                                      |
|     Exchange (HashPartitioning [key#37:0], 200)                                     |
|      Aggregate true, [key#37], [key#37,COUNT(1) AS PartialCount#39L]                |
|       HiveTableScan [key#37], (MetastoreRelation default, shark_table, None), None  |
+-------------------------------------------------------------------------------------+
7 rows selected (0.109 seconds)
0: jdbc:hive2://localhost:10000> select key, count(*) from shark_table group by key limit 10;        
+------+------+
| key  | c_1  |
+------+------+
| 152  | 2    |
| 76   | 2    |
| 128  | 3    |
| 311  | 3    |
| 316  | 3    |
| 435  | 1    |
| 323  | 1    |
| 27   | 1    |
| 190  | 1    |
| 406  | 4    |
+------+------+
10 rows selected (1.91 seconds)
0: jdbc:hive2://localhost:10000>
```
