### PR TITLE
Add support to clear-buffer-cache.py for checking SPARK_HOME for slaves

### DIFF
--- a/bin/dev/clear-buffer-cache.py
+++ b/bin/dev/clear-buffer-cache.py
@@ -24,17 +24,18 @@ import sys
 
 EC2_MACHINES_FILE = "/root/spark-ec2/slaves"
 
-spark_home = os.getenv("SPARK_HOME")
-if spark_home is None:
+sparkHome = os.getenv("SPARK_HOME")
+
+machinesFile = None
+if os.path.exists(EC2_MACHINES_FILE):
   machinesFile = EC2_MACHINES_FILE
-  if not os.path.exists(machinesFile):
-    print "Could not find Spark slaves file.  SPARK_HOME is not set and could not find file at %s" % EC2_MACHINES_FILE
-    sys.exit(1)
-else:
-  machinesFile = spark_home + "/conf/slaves"
-  if not os.path.exists(machinesFile):
-    print "Could not find Spark slaves file. Based on SPARK_HOME, expected file to be located at %s" % machinesFile
-    sys.exit(1)
+elif sparkHome is not None and os.path.exists(sparkHome + "/conf/slaves"):
+  machinesFile = sparkHome + "/conf/slaves"
+
+if machinesFile is None:
+  print "Could not find Spark slaves file."
+  sys.exit(1)
+
     
 machs = open(machinesFile).readlines()
 machs = map(lambda s: s.strip(),machs)

--- a/bin/dev/clear-buffer-cache.py
+++ b/bin/dev/clear-buffer-cache.py
@@ -20,8 +20,22 @@
 import os
 import thread
 import time
+import sys
 
-machinesFile = "/root/spark-ec2/slaves"
+EC2_MACHINES_FILE = "/root/spark-ec2/slaves"
+
+spark_home = os.getenv("SPARK_HOME")
+if spark_home is None:
+  machinesFile = EC2_MACHINES_FILE
+  if not os.path.exists(machinesFile):
+    print "Could not find Spark slaves file.  SPARK_HOME is not set and could not find file at %s" % EC2_MACHINES_FILE
+    sys.exit(1)
+else:
+  machinesFile = spark_home + "/conf/slaves"
+  if not os.path.exists(machinesFile):
+    print "Could not find Spark slaves file. Based on SPARK_HOME, expected file to be located at %s" % machinesFile
+    sys.exit(1)
+    
 machs = open(machinesFile).readlines()
 machs = map(lambda s: s.strip(),machs)
 machCount = len(machs)


### PR DESCRIPTION
clear-buffer-cache.py assumes the slaves file is located under /root/spark-ec2/slaves .  This is not consistent with the Spark setup guide for custom deployments.

I added the ability to find the slaves file relative to the SPARK_HOME environmental variable, if set.  If the slaves file cannot be found in either location, an error is raised.
